### PR TITLE
Add default spawn point to stage editor

### DIFF
--- a/src/components/stage-editor/UnifiedStageEditor.tsx
+++ b/src/components/stage-editor/UnifiedStageEditor.tsx
@@ -126,6 +126,9 @@ export default function UnifiedStageEditor() {
   const [portalPreviewModel, setPortalPreviewModel] = useState<PreviewModel>('Gate');
   const [selectedPortalId, setSelectedPortalId] = useState<string | null>(null);
 
+  // Default spawn placement state
+  const [spawnPlacementMode, setSpawnPlacementMode] = useState(false);
+
   // Obstacle placement state
   const [obstaclePlacementMode, setObstaclePlacementMode] = useState(false);
   const [obstaclePlacementType, setObstaclePlacementType] = useState<ObstacleType>('box');
@@ -255,6 +258,29 @@ export default function UnifiedStageEditor() {
     [portalPlacementDirection, updateConfig]
   );
 
+  // Handle default spawn placement
+  const handlePlaceDefaultSpawn = useCallback(
+    (position: [number, number, number]) => {
+      updateConfig((prev) => ({
+        ...prev,
+        defaultSpawn: { position, direction: portalPlacementDirection },
+      }));
+      setSpawnPlacementMode(false);
+    },
+    [portalPlacementDirection, updateConfig]
+  );
+
+  // Mutual exclusion wrappers for placement modes
+  const setPortalPlacementModeExclusive = useCallback((mode: boolean) => {
+    setPortalPlacementMode(mode);
+    if (mode) setSpawnPlacementMode(false);
+  }, []);
+
+  const setSpawnPlacementModeExclusive = useCallback((mode: boolean) => {
+    setSpawnPlacementMode(mode);
+    if (mode) setPortalPlacementMode(false);
+  }, []);
+
   // Handle portal click in canvas
   const handlePortalClick = useCallback((id: string) => {
     setSelectedPortalId(id);
@@ -333,13 +359,15 @@ export default function UnifiedStageEditor() {
             config={config}
             updateConfig={updateConfig}
             placementMode={portalPlacementMode}
-            setPlacementMode={setPortalPlacementMode}
+            setPlacementMode={setPortalPlacementModeExclusive}
             placementDirection={portalPlacementDirection}
             setPlacementDirection={setPortalPlacementDirection}
             previewModel={portalPreviewModel}
             setPreviewModel={setPortalPreviewModel}
             selectedPortalId={selectedPortalId}
             setSelectedPortalId={setSelectedPortalId}
+            spawnPlacementMode={spawnPlacementMode}
+            setSpawnPlacementMode={setSpawnPlacementModeExclusive}
           />
         );
       case 'textures':
@@ -433,6 +461,9 @@ export default function UnifiedStageEditor() {
             onPortalClick={handlePortalClick}
             onPlacePortal={handlePlacePortal}
             onUpdatePortalPosition={handleUpdatePortalPosition}
+            defaultSpawn={config.defaultSpawn}
+            spawnPlacementMode={spawnPlacementMode}
+            onPlaceDefaultSpawn={handlePlaceDefaultSpawn}
           />
         );
       case 'obstacles':

--- a/src/components/stage-editor/shared/PortalOverlay.tsx
+++ b/src/components/stage-editor/shared/PortalOverlay.tsx
@@ -3,7 +3,7 @@ import { useGLTF } from '@react-three/drei';
 import { useThree, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
-import type { PortalData, GateDirection, PreviewModel } from '../types';
+import type { PortalData, GateDirection, PreviewModel, SpawnPointData } from '../types';
 import { DIRECTION_ROTATIONS } from '../types';
 
 // Model paths
@@ -41,29 +41,28 @@ function computeMarkerPositions(position: [number, number, number], direction: G
   };
 }
 
-// Spawn point marker (green sphere with ring and arrow)
-function SpawnMarker({ position, rotation }: { position: [number, number, number]; rotation: number }) {
+// Spawn point marker (sphere with ring and arrow)
+function SpawnMarker({ position, rotation, color = "#00ff00" }: { position: [number, number, number]; rotation: number; color?: string }) {
   return (
     <group position={position}>
-      {/* Green sphere */}
       <mesh>
         <sphereGeometry args={[0.8, 16, 16]} />
-        <meshBasicMaterial color="#00ff00" transparent opacity={0.7} />
+        <meshBasicMaterial color={color} transparent opacity={0.7} />
       </mesh>
       {/* Ring on ground */}
       <mesh rotation={[-Math.PI / 2, 0, 0]}>
         <ringGeometry args={[1, 1.3, 32]} />
-        <meshBasicMaterial color="#00ff00" side={THREE.DoubleSide} />
+        <meshBasicMaterial color={color} side={THREE.DoubleSide} />
       </mesh>
       {/* Direction arrow */}
       <group rotation={[0, rotation, 0]}>
         <mesh position={[0, 0.3, 1]}>
           <boxGeometry args={[0.2, 0.2, 1.5]} />
-          <meshBasicMaterial color="#00ff00" />
+          <meshBasicMaterial color={color} />
         </mesh>
         <mesh position={[0, 0.3, 2]} rotation={[Math.PI / 2, 0, 0]}>
           <coneGeometry args={[0.4, 0.6, 8]} />
-          <meshBasicMaterial color="#00ff00" />
+          <meshBasicMaterial color={color} />
         </mesh>
       </group>
     </group>
@@ -232,6 +231,9 @@ interface PortalOverlayProps {
   onPortalClick: (id: string) => void;
   onPlacePortal: (position: [number, number, number]) => void;
   onUpdatePortalPosition?: (id: string, position: [number, number, number]) => void;
+  defaultSpawn?: SpawnPointData;
+  spawnPlacementMode?: boolean;
+  onPlaceDefaultSpawn?: (position: [number, number, number]) => void;
 }
 
 // Spawn marker for placement preview (semi-transparent)
@@ -346,6 +348,30 @@ function PlacementPreview({
   );
 }
 
+// Spawn-only placement preview (follows mouse, shows just the spawn marker)
+function SpawnPlacementPreview({ direction }: { direction: GateDirection }) {
+  const { camera, raycaster, pointer } = useThree();
+  const groupRef = useRef<THREE.Group>(null);
+  const groundPlane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), 0), []);
+  const intersection = useMemo(() => new THREE.Vector3(), []);
+
+  useFrame(() => {
+    if (!groupRef.current) return;
+    raycaster.setFromCamera(pointer, camera);
+    if (raycaster.ray.intersectPlane(groundPlane, intersection)) {
+      groupRef.current.position.set(intersection.x, 0, intersection.z);
+    }
+  });
+
+  const rotation = DIRECTION_ROTATIONS[direction];
+
+  return (
+    <group ref={groupRef}>
+      <SpawnMarker position={[0, 1, 0]} rotation={rotation} color="#ffff00" />
+    </group>
+  );
+}
+
 // Static preview components that don't need position (position is on parent group)
 function GatePreviewStatic({ opacity }: { opacity: number }) {
   const { scene } = useGLTF(GATE_MODEL_PATH);
@@ -402,25 +428,32 @@ export default function PortalOverlay({
   onPortalClick,
   onPlacePortal,
   onUpdatePortalPosition,
+  defaultSpawn,
+  spawnPlacementMode,
+  onPlaceDefaultSpawn,
 }: PortalOverlayProps) {
   const { camera, raycaster, pointer } = useThree();
   const groundPlane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), 0), []);
   const intersection = useMemo(() => new THREE.Vector3(), []);
 
+  const anyPlacementMode = placementMode || spawnPlacementMode;
+
   // Handle click to place - get position from raycaster at click time
   const handleCanvasClick = useCallback(() => {
-    if (!placementMode) return;
-
     raycaster.setFromCamera(pointer, camera);
-    if (raycaster.ray.intersectPlane(groundPlane, intersection)) {
+    if (!raycaster.ray.intersectPlane(groundPlane, intersection)) return;
+
+    if (placementMode) {
       onPlacePortal([intersection.x, 0, intersection.z]);
+    } else if (spawnPlacementMode && onPlaceDefaultSpawn) {
+      onPlaceDefaultSpawn([intersection.x, 0, intersection.z]);
     }
-  }, [placementMode, raycaster, pointer, camera, groundPlane, intersection, onPlacePortal]);
+  }, [placementMode, spawnPlacementMode, raycaster, pointer, camera, groundPlane, intersection, onPlacePortal, onPlaceDefaultSpawn]);
 
   return (
     <group>
       {/* Ground plane for click detection in placement mode */}
-      {placementMode && (
+      {anyPlacementMode && (
         <mesh
           rotation={[-Math.PI / 2, 0, 0]}
           position={[0, 0.01, 0]}
@@ -444,12 +477,22 @@ export default function PortalOverlay({
         />
       ))}
 
+      {/* Default spawn marker (yellow) */}
+      {defaultSpawn && (
+        <SpawnMarker position={defaultSpawn.position} rotation={DIRECTION_ROTATIONS[defaultSpawn.direction]} color="#ffff00" />
+      )}
+
       {/* Preview portal when in placement mode - follows mouse */}
       {placementMode && (
         <PlacementPreview
           direction={placementDirection}
           modelType={previewModel}
         />
+      )}
+
+      {/* Preview spawn marker when in spawn placement mode */}
+      {spawnPlacementMode && (
+        <SpawnPlacementPreview direction={placementDirection} />
       )}
     </group>
   );

--- a/src/components/stage-editor/tabs/ExportTab.tsx
+++ b/src/components/stage-editor/tabs/ExportTab.tsx
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import JSZip from 'jszip';
-import type { UnifiedStageConfig, FloorTriangle, PortalData } from '../types';
+import type { UnifiedStageConfig, FloorTriangle, PortalData, SpawnPointData } from '../types';
 import { STAGE_AREAS, getGlbPath, getAreaFromMapId } from '../constants';
 import { DIRECTION_ROTATIONS } from '../types';
 
@@ -260,19 +260,20 @@ function createTriggerMarker(
 
   // Trigger box (matches gate width, 3 units tall, 2 units deep)
   const boxGeometry = new THREE.BoxGeometry(GATE_WIDTH, 3, 2);
-  const boxMaterial = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.3 });
-  const box = new THREE.Mesh(boxGeometry, boxMaterial);
-  box.position.y = 1.5; // Center is 1.5 units up
-  box.name = `${name}_box-colonly`;
-  group.add(box);
 
-  // Trigger wireframe
-  const wireGeometry = new THREE.EdgesGeometry(boxGeometry);
-  const wireMaterial = new THREE.LineBasicMaterial({ color });
-  const wireframe = new THREE.LineSegments(wireGeometry, wireMaterial);
-  wireframe.position.y = 1.5;
-  wireframe.name = `${name}_wire`;
-  group.add(wireframe);
+  // Visible mesh (Godot strips -colonly meshes visually, and LINES aren't supported)
+  const visMaterial = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.3 });
+  const visMesh = new THREE.Mesh(boxGeometry, visMaterial);
+  visMesh.position.y = 1.5;
+  visMesh.name = `${name}_vis`;
+  group.add(visMesh);
+
+  // Collision mesh (Godot auto-imports as StaticBody3D)
+  const colMaterial = new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.0 });
+  const colMesh = new THREE.Mesh(boxGeometry, colMaterial);
+  colMesh.position.y = 1.5;
+  colMesh.name = `${name}_box-colonly`;
+  group.add(colMesh);
 
   return group;
 }
@@ -488,6 +489,23 @@ async function buildExportScene(
       portalsGroup.add(triggerMarker);
     });
 
+    // Export default spawn point (for boss rooms / gateless areas)
+    if (stageConfig.defaultSpawn) {
+      const rotation = DIRECTION_ROTATIONS[stageConfig.defaultSpawn.direction];
+      const pos: [number, number, number] = [
+        stageConfig.defaultSpawn.position[0],
+        1, // Match portal spawn height so marker is above ground
+        stageConfig.defaultSpawn.position[2],
+      ];
+      const spawnMarker = createSpawnMarker(
+        'spawn_default',
+        pos,
+        rotation,
+        0xffff00 // Yellow to distinguish from portal spawns
+      );
+      portalsGroup.add(spawnMarker);
+    }
+
     exportScene.add(portalsGroup);
   }
 
@@ -639,6 +657,23 @@ export default function ExportTab({ config, stageScene, mapId }: ExportTabProps)
           );
           portalsGroup.add(triggerMarker);
         });
+
+        // Export default spawn point (for boss rooms / gateless areas)
+        if (config.defaultSpawn) {
+          const rotation = DIRECTION_ROTATIONS[config.defaultSpawn.direction];
+          const pos: [number, number, number] = [
+            config.defaultSpawn.position[0],
+            1, // Match portal spawn height so marker is above ground
+            config.defaultSpawn.position[2],
+          ];
+          const spawnMarker = createSpawnMarker(
+            'spawn_default',
+            pos,
+            rotation,
+            0xffff00 // Yellow to distinguish from portal spawns
+          );
+          portalsGroup.add(spawnMarker);
+        }
 
         exportScene.add(portalsGroup);
       }

--- a/src/components/stage-editor/tabs/PortalTab.tsx
+++ b/src/components/stage-editor/tabs/PortalTab.tsx
@@ -1,4 +1,4 @@
-import type { UnifiedStageConfig, PortalData, GateDirection, PreviewModel } from '../types';
+import type { UnifiedStageConfig, PortalData, GateDirection, PreviewModel, SpawnPointData } from '../types';
 import { DIRECTION_ROTATIONS } from '../types';
 
 interface PortalTabProps {
@@ -13,6 +13,8 @@ interface PortalTabProps {
   setPreviewModel: (model: PreviewModel) => void;
   selectedPortalId: string | null;
   setSelectedPortalId: (id: string | null) => void;
+  spawnPlacementMode: boolean;
+  setSpawnPlacementMode: (mode: boolean) => void;
 }
 
 const DIRECTIONS: GateDirection[] = ['north', 'south', 'east', 'west'];
@@ -29,6 +31,8 @@ export default function PortalTab({
   setPreviewModel,
   selectedPortalId,
   setSelectedPortalId,
+  spawnPlacementMode,
+  setSpawnPlacementMode,
 }: PortalTabProps) {
   // Get selected portal
   const selectedPortal = config.portals.find((p) => p.id === selectedPortalId);
@@ -344,6 +348,164 @@ export default function PortalTab({
         <p style={{ margin: '4px 0' }}>• <b>Click in the scene</b> where you want to place the portal</p>
         <p style={{ margin: '4px 0' }}>• Click an existing portal to select and adjust its position</p>
       </div>
+
+      {/* Default Spawn Point */}
+      <h3 style={{ margin: '16px 0 0 0', borderBottom: '1px solid #444', paddingBottom: '8px' }}>
+        Default Spawn Point
+      </h3>
+
+      <div style={{ fontSize: '11px', color: '#666', marginBottom: '8px' }}>
+        For boss rooms and areas without gate portals. Exported as <code>spawn_default</code>.
+      </div>
+
+      <div>
+        <button
+          onClick={() => {
+            const next = !spawnPlacementMode;
+            setSpawnPlacementMode(next);
+            if (next) setPlacementMode(false);
+          }}
+          style={{
+            width: '100%',
+            padding: '12px',
+            background: spawnPlacementMode ? '#ccaa00' : '#333',
+            color: spawnPlacementMode ? 'black' : 'white',
+            border: spawnPlacementMode ? '2px solid #ffdd00' : '2px solid transparent',
+            borderRadius: '4px',
+            cursor: 'pointer',
+            fontWeight: 'bold',
+            fontSize: '14px',
+          }}
+        >
+          {spawnPlacementMode ? '✓ Click in scene to place spawn' : 'Place Default Spawn'}
+        </button>
+      </div>
+
+      {config.defaultSpawn ? (
+        <div
+          style={{
+            padding: '12px',
+            background: '#1a1a2e',
+            borderRadius: '4px',
+          }}
+        >
+          <h4 style={{ margin: '0 0 12px 0', fontSize: '12px', color: '#888' }}>
+            Edit Default Spawn
+          </h4>
+
+          {/* Direction */}
+          <div style={{ marginBottom: '12px' }}>
+            <label style={{ display: 'block', marginBottom: '4px', fontSize: '11px', color: '#666' }}>
+              Direction:
+            </label>
+            <div style={{ display: 'flex', gap: '4px' }}>
+              {DIRECTIONS.map((dir) => (
+                <button
+                  key={dir}
+                  onClick={() =>
+                    updateConfig((prev) => ({
+                      ...prev,
+                      defaultSpawn: { ...prev.defaultSpawn!, direction: dir },
+                    }))
+                  }
+                  style={{
+                    flex: 1,
+                    padding: '6px',
+                    background: config.defaultSpawn!.direction === dir ? '#ccaa00' : '#333',
+                    color: config.defaultSpawn!.direction === dir ? 'black' : 'white',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    textTransform: 'uppercase',
+                    fontSize: '11px',
+                  }}
+                >
+                  {dir.charAt(0)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Position X/Z */}
+          <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
+            <div style={{ flex: 1 }}>
+              <label style={{ display: 'block', marginBottom: '4px', fontSize: '11px', color: '#666' }}>
+                X Position:
+              </label>
+              <input
+                type="number"
+                step="0.1"
+                value={config.defaultSpawn.position[0]}
+                onChange={(e) =>
+                  updateConfig((prev) => {
+                    const pos: [number, number, number] = [...prev.defaultSpawn!.position];
+                    pos[0] = parseFloat(e.target.value) || 0;
+                    return { ...prev, defaultSpawn: { ...prev.defaultSpawn!, position: pos } };
+                  })
+                }
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  background: '#252540',
+                  color: 'white',
+                  border: '1px solid #444',
+                  borderRadius: '4px',
+                }}
+              />
+            </div>
+            <div style={{ flex: 1 }}>
+              <label style={{ display: 'block', marginBottom: '4px', fontSize: '11px', color: '#666' }}>
+                Z Position:
+              </label>
+              <input
+                type="number"
+                step="0.1"
+                value={config.defaultSpawn.position[2]}
+                onChange={(e) =>
+                  updateConfig((prev) => {
+                    const pos: [number, number, number] = [...prev.defaultSpawn!.position];
+                    pos[2] = parseFloat(e.target.value) || 0;
+                    return { ...prev, defaultSpawn: { ...prev.defaultSpawn!, position: pos } };
+                  })
+                }
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  background: '#252540',
+                  color: 'white',
+                  border: '1px solid #444',
+                  borderRadius: '4px',
+                }}
+              />
+            </div>
+          </div>
+
+          <button
+            onClick={() =>
+              updateConfig((prev) => {
+                const { defaultSpawn: _, ...rest } = prev;
+                return rest as UnifiedStageConfig;
+              })
+            }
+            style={{
+              width: '100%',
+              padding: '8px',
+              background: '#a44',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer',
+              fontSize: '12px',
+            }}
+          >
+            Clear Default Spawn
+          </button>
+        </div>
+      ) : (
+        <div style={{ fontSize: '11px', color: '#666', fontStyle: 'italic' }}>
+          No default spawn set.
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/stage-editor/types.ts
+++ b/src/components/stage-editor/types.ts
@@ -35,6 +35,11 @@ export interface PortalData {
   label: string;
 }
 
+export interface SpawnPointData {
+  position: [number, number, number];
+  direction: GateDirection;
+}
+
 // Rotation values for each direction (radians, Y-axis rotation)
 export const DIRECTION_ROTATIONS: Record<GateDirection, number> = {
   north: 0,
@@ -79,6 +84,7 @@ export interface UnifiedStageConfig {
   // gridSize and gridOffset removed - they're visual helpers only, not saved config
   floorCollision: FloorCollisionConfig;
   portals: PortalData[];
+  defaultSpawn?: SpawnPointData;
   textureFixes: TextureFix[];
   obstacles: ObstacleData[];
   svgSettings?: SvgSettings;


### PR DESCRIPTION
## Summary
- Adds `SpawnPointData` type and optional `defaultSpawn` field to stage config
- New placement UI in Portal tab with direction selector and position editing
- Yellow spawn marker renders in 3D overlay during editing
- Exports `spawn_default` node in GLB for Godot to discover in boss rooms / gateless areas
- Trigger markers now export visible mesh alongside `-colonly` collision mesh (Godot strips visual from -colonly)

## Test plan
- [ ] Navigate to `/stage/stage-editor?map=s01z_na1&tab=portals`
- [ ] Place a default spawn — verify yellow marker appears
- [ ] Change direction and clear — verify UI updates
- [ ] Export GLB and verify `portals/spawn_default` node exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)