### PR TITLE
Add portal rotation offset (+/- 45°)

### DIFF
--- a/src/components/stage-editor/UnifiedStageEditor.tsx
+++ b/src/components/stage-editor/UnifiedStageEditor.tsx
@@ -123,6 +123,7 @@ export default function UnifiedStageEditor() {
   // Portal placement state
   const [portalPlacementMode, setPortalPlacementMode] = useState(false);
   const [portalPlacementDirection, setPortalPlacementDirection] = useState<GateDirection>('north');
+  const [portalPlacementRotationOffset, setPortalPlacementRotationOffset] = useState(0);
   const [portalPreviewModel, setPortalPreviewModel] = useState<PreviewModel>('Gate');
   const [selectedPortalId, setSelectedPortalId] = useState<string | null>(null);
 
@@ -244,6 +245,7 @@ export default function UnifiedStageEditor() {
         direction: portalPlacementDirection,
         position,
         label: portalPlacementDirection, // Default label to direction
+        ...(portalPlacementRotationOffset ? { rotationOffset: portalPlacementRotationOffset } : {}),
       };
 
       updateConfig((prev) => ({
@@ -255,7 +257,7 @@ export default function UnifiedStageEditor() {
       setSelectedPortalId(id);
       setPortalPlacementMode(false);
     },
-    [portalPlacementDirection, updateConfig]
+    [portalPlacementDirection, portalPlacementRotationOffset, updateConfig]
   );
 
   // Handle default spawn placement
@@ -362,6 +364,8 @@ export default function UnifiedStageEditor() {
             setPlacementMode={setPortalPlacementModeExclusive}
             placementDirection={portalPlacementDirection}
             setPlacementDirection={setPortalPlacementDirection}
+            placementRotationOffset={portalPlacementRotationOffset}
+            setPlacementRotationOffset={setPortalPlacementRotationOffset}
             previewModel={portalPreviewModel}
             setPreviewModel={setPortalPreviewModel}
             selectedPortalId={selectedPortalId}
@@ -457,6 +461,7 @@ export default function UnifiedStageEditor() {
             selectedPortalId={selectedPortalId}
             placementMode={portalPlacementMode}
             placementDirection={portalPlacementDirection}
+            placementRotationOffset={portalPlacementRotationOffset}
             previewModel={portalPreviewModel}
             onPortalClick={handlePortalClick}
             onPlacePortal={handlePlacePortal}

--- a/src/components/stage-editor/shared/PortalOverlay.tsx
+++ b/src/components/stage-editor/shared/PortalOverlay.tsx
@@ -4,7 +4,7 @@ import { useThree, useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import * as SkeletonUtils from 'three/examples/jsm/utils/SkeletonUtils.js';
 import type { PortalData, GateDirection, PreviewModel, SpawnPointData } from '../types';
-import { DIRECTION_ROTATIONS } from '../types';
+import { DIRECTION_ROTATIONS, getPortalRotation } from '../types';
 
 // Model paths
 const GATE_MODEL_PATH = '/objects/01_o01a/o0c_gate.imd/o0c_gate.glb';
@@ -12,7 +12,7 @@ const WARP_MODEL_PATH = '/objects/special_z/o0s_warpm.imd/o0s_warpm.glb';
 
 interface PortalModelProps {
   position: [number, number, number];
-  direction: GateDirection;
+  rotation: number; // effective rotation in radians
   modelType: PreviewModel;
   opacity?: number;
   selected?: boolean;
@@ -25,10 +25,9 @@ const SPAWN_OUTSET = 3;   // Spawn behind the gate (outside)
 const TRIGGER_OUTSET = 7; // Trigger further out, player hits it first
 const GATE_WIDTH = 6.0;
 
-// Compute spawn and trigger positions from gate position and direction
-function computeMarkerPositions(position: [number, number, number], direction: GateDirection) {
+// Compute spawn and trigger positions from gate position and rotation (radians)
+function computeMarkerPositions(position: [number, number, number], rotation: number) {
   const [x, , z] = position;
-  const rotation = DIRECTION_ROTATIONS[direction];
   const cos = Math.cos(rotation);
   const sin = Math.sin(rotation);
 
@@ -107,9 +106,8 @@ function GateBoundingBox({ position, rotation }: { position: [number, number, nu
   );
 }
 
-function GatePreview({ position, direction, opacity = 1, selected, onClick }: Omit<PortalModelProps, 'modelType'>) {
+function GatePreview({ position, rotation, opacity = 1, selected, onClick }: Omit<PortalModelProps, 'modelType'>) {
   const { scene } = useGLTF(GATE_MODEL_PATH);
-  const rotation = DIRECTION_ROTATIONS[direction];
 
   const clonedScene = useMemo(() => {
     const clone = SkeletonUtils.clone(scene);
@@ -130,7 +128,7 @@ function GatePreview({ position, direction, opacity = 1, selected, onClick }: Om
   }, [scene, opacity]);
 
   // Compute spawn/trigger positions
-  const markers = useMemo(() => computeMarkerPositions(position, direction), [position, direction]);
+  const markers = useMemo(() => computeMarkerPositions(position, rotation), [position, rotation]);
 
   return (
     <group>
@@ -161,9 +159,8 @@ function GatePreview({ position, direction, opacity = 1, selected, onClick }: Om
   );
 }
 
-function WarpPreview({ position, direction, opacity = 1, selected, onClick }: Omit<PortalModelProps, 'modelType'>) {
+function WarpPreview({ position, rotation, opacity = 1, selected, onClick }: Omit<PortalModelProps, 'modelType'>) {
   const { scene } = useGLTF(WARP_MODEL_PATH);
-  const rotation = DIRECTION_ROTATIONS[direction];
 
   const clonedScene = useMemo(() => {
     const clone = SkeletonUtils.clone(scene);
@@ -184,7 +181,7 @@ function WarpPreview({ position, direction, opacity = 1, selected, onClick }: Om
   }, [scene, opacity]);
 
   // Compute spawn/trigger positions
-  const markers = useMemo(() => computeMarkerPositions(position, direction), [position, direction]);
+  const markers = useMemo(() => computeMarkerPositions(position, rotation), [position, rotation]);
 
   return (
     <group>
@@ -227,6 +224,7 @@ interface PortalOverlayProps {
   selectedPortalId: string | null;
   placementMode: boolean;
   placementDirection: GateDirection;
+  placementRotationOffset: number; // degrees
   previewModel: PreviewModel;
   onPortalClick: (id: string) => void;
   onPlacePortal: (position: [number, number, number]) => void;
@@ -299,10 +297,10 @@ function GateBoundingBoxPreview() {
 
 // Separate component for the preview that follows the mouse
 function PlacementPreview({
-  direction,
+  rotation,
   modelType
 }: {
-  direction: GateDirection;
+  rotation: number; // effective rotation in radians
   modelType: PreviewModel;
 }) {
   const { camera, raycaster, pointer } = useThree();
@@ -321,8 +319,6 @@ function PlacementPreview({
       positionRef.current = [intersection.x, 0, intersection.z];
     }
   });
-
-  const rotation = DIRECTION_ROTATIONS[direction];
 
   // Local space offsets for spawn/trigger (in the direction the gate faces)
   // Order from outside to inside: trigger → spawn → gate
@@ -424,6 +420,7 @@ export default function PortalOverlay({
   selectedPortalId,
   placementMode,
   placementDirection,
+  placementRotationOffset,
   previewModel,
   onPortalClick,
   onPlacePortal,
@@ -469,7 +466,7 @@ export default function PortalOverlay({
         <PortalModel
           key={portal.id}
           position={portal.position}
-          direction={portal.direction}
+          rotation={getPortalRotation(portal)}
           modelType={previewModel}
           opacity={1}
           selected={portal.id === selectedPortalId}
@@ -485,7 +482,7 @@ export default function PortalOverlay({
       {/* Preview portal when in placement mode - follows mouse */}
       {placementMode && (
         <PlacementPreview
-          direction={placementDirection}
+          rotation={DIRECTION_ROTATIONS[placementDirection] + (placementRotationOffset * Math.PI) / 180}
           modelType={previewModel}
         />
       )}

--- a/src/components/stage-editor/tabs/ExportTab.tsx
+++ b/src/components/stage-editor/tabs/ExportTab.tsx
@@ -3,9 +3,10 @@ import * as THREE from 'three';
 import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import JSZip from 'jszip';
-import type { UnifiedStageConfig, FloorTriangle, PortalData, SpawnPointData } from '../types';
+import type { UnifiedStageConfig, FloorTriangle, PortalData, SpawnPointData, TextureFix } from '../types';
 import { STAGE_AREAS, getGlbPath, getAreaFromMapId } from '../constants';
-import { DIRECTION_ROTATIONS } from '../types';
+import { DIRECTION_ROTATIONS, getPortalRotation } from '../types';
+import { loadGlobalFixes } from './TextureTab';
 
 // Helper to compute spawn and trigger positions from portal position and direction
 // Matches PortalEditor's calculatePortalPositions offsets
@@ -16,7 +17,7 @@ function computePortalPositions(portal: PortalData): {
   rotation: number;
 } {
   const [x, , z] = portal.position;
-  const rotation = DIRECTION_ROTATIONS[portal.direction];
+  const rotation = getPortalRotation(portal);
 
   // Match PortalOverlay's offsets:
   // Order from outside to inside: trigger → spawn → gate
@@ -112,6 +113,73 @@ function extractFloorTriangles(scene: THREE.Object3D, yTolerance: number): Floor
   });
 
   return triangles;
+}
+
+// Build textureFixes array from scene meshes + global fixes in localStorage
+function buildTextureFixes(scene: THREE.Object3D): TextureFix[] {
+  const globalFixes = loadGlobalFixes();
+  if (Object.keys(globalFixes).length === 0) return [];
+
+  // Scan scene for texture→mesh mappings, same pattern as TextureTab's extractTextures
+  const textureInstanceCounts: Record<string, number> = {};
+  const keyToMeshNames: Record<string, string[]> = {};
+  const keyToFilename: Record<string, string> = {};
+
+  scene.traverse((object) => {
+    if (!(object as THREE.Mesh).isMesh) return;
+    const mesh = object as THREE.Mesh;
+    const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+
+    materials.forEach((mat) => {
+      const m = mat as any;
+      if (m.map && m.map instanceof THREE.Texture) {
+        let filename = 'unknown';
+        if (m.map.name) {
+          const parts = m.map.name.split('/');
+          filename = parts[parts.length - 1];
+        } else if (m.map.image?.src) {
+          const parts = m.map.image.src.split('/');
+          filename = parts[parts.length - 1];
+        }
+
+        textureInstanceCounts[filename] = (textureInstanceCounts[filename] || 0) + 1;
+        const instanceNum = textureInstanceCounts[filename];
+        const key = `${filename}#${instanceNum}`;
+
+        keyToFilename[key] = filename;
+        if (!keyToMeshNames[key]) keyToMeshNames[key] = [];
+        keyToMeshNames[key].push(mesh.name);
+      }
+    });
+  });
+
+  // Match each texture key against global fixes
+  const fixes: TextureFix[] = [];
+  for (const [key, fix] of Object.entries(globalFixes)) {
+    if (!keyToFilename[key]) continue;
+
+    // Skip entries that are all defaults
+    const isDefault =
+      fix.repeatX === 1 && fix.repeatY === 1 &&
+      fix.offsetX === 0 && fix.offsetY === 0 &&
+      (!fix.wrapS || fix.wrapS === 'repeat') &&
+      (!fix.wrapT || fix.wrapT === 'repeat');
+    if (isDefault) continue;
+
+    const entry: TextureFix = {
+      textureFile: keyToFilename[key],
+      meshNames: keyToMeshNames[key] || [],
+      repeatX: fix.repeatX,
+      repeatY: fix.repeatY,
+      offsetX: fix.offsetX,
+      offsetY: fix.offsetY,
+    };
+    if (fix.wrapS && fix.wrapS !== 'repeat') entry.wrapS = fix.wrapS;
+    if (fix.wrapT && fix.wrapT !== 'repeat') entry.wrapT = fix.wrapT;
+    fixes.push(entry);
+  }
+
+  return fixes;
 }
 
 // Convert MeshBasicMaterial to MeshLambertMaterial
@@ -719,8 +787,10 @@ export default function ExportTab({ config, stageScene, mapId }: ExportTabProps)
 
   // Export config JSON
   const exportConfig = () => {
+    const textureFixes = stageScene ? buildTextureFixes(stageScene) : config.textureFixes;
     const exportData = {
       ...config,
+      textureFixes,
       exportedAt: new Date().toISOString(),
     };
     const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
@@ -791,8 +861,9 @@ export default function ExportTab({ config, stageScene, mapId }: ExportTabProps)
           // Generate SVG
           const svg = generateSvgMinimap(tris, stageConfig);
 
-          // Generate config JSON
-          const configJson = JSON.stringify({ ...stageConfig, exportedAt: new Date().toISOString() }, null, 2);
+          // Generate config JSON (populate textureFixes from scene + global fixes)
+          const textureFixes = buildTextureFixes(scene);
+          const configJson = JSON.stringify({ ...stageConfig, textureFixes, exportedAt: new Date().toISOString() }, null, 2);
 
           // Add to zip (organized by area)
           const folder = zip.folder(areaKey) || zip;

--- a/src/components/stage-editor/tabs/ObstacleTab.tsx
+++ b/src/components/stage-editor/tabs/ObstacleTab.tsx
@@ -236,7 +236,7 @@ export default function ObstacleTab({
               <label style={{ fontSize: '10px', color: '#666' }}>Rotation Y:</label>
               <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '4px' }}>
                 <button
-                  onClick={() => setPlacementDimensions({ ...placementDimensions, rotationY: placementDimensions.rotationY - 15 })}
+                  onClick={() => setPlacementDimensions({ ...placementDimensions, rotationY: placementDimensions.rotationY - 5 })}
                   style={{
                     padding: '6px 12px',
                     background: '#444',
@@ -246,13 +246,13 @@ export default function ObstacleTab({
                     cursor: 'pointer',
                   }}
                 >
-                  -15°
+                  -5°
                 </button>
                 <span style={{ flex: 1, textAlign: 'center', fontSize: '14px' }}>
                   {placementDimensions.rotationY}°
                 </span>
                 <button
-                  onClick={() => setPlacementDimensions({ ...placementDimensions, rotationY: placementDimensions.rotationY + 15 })}
+                  onClick={() => setPlacementDimensions({ ...placementDimensions, rotationY: placementDimensions.rotationY + 5 })}
                   style={{
                     padding: '6px 12px',
                     background: '#444',
@@ -262,7 +262,7 @@ export default function ObstacleTab({
                     cursor: 'pointer',
                   }}
                 >
-                  +15°
+                  +5°
                 </button>
               </div>
             </div>

--- a/src/components/stage-editor/tabs/PortalTab.tsx
+++ b/src/components/stage-editor/tabs/PortalTab.tsx
@@ -9,6 +9,8 @@ interface PortalTabProps {
   setPlacementMode: (mode: boolean) => void;
   placementDirection: GateDirection;
   setPlacementDirection: (dir: GateDirection) => void;
+  placementRotationOffset: number;
+  setPlacementRotationOffset: (offset: number) => void;
   previewModel: PreviewModel;
   setPreviewModel: (model: PreviewModel) => void;
   selectedPortalId: string | null;
@@ -27,6 +29,8 @@ export default function PortalTab({
   setPlacementMode,
   placementDirection,
   setPlacementDirection,
+  placementRotationOffset,
+  setPlacementRotationOffset,
   previewModel,
   setPreviewModel,
   selectedPortalId,
@@ -64,6 +68,16 @@ export default function PortalTab({
       ...prev,
       portals: prev.portals.map((p) =>
         p.id === id ? { ...p, direction } : p
+      ),
+    }));
+  };
+
+  // Update portal rotation offset
+  const updatePortalRotationOffset = (id: string, offset: number) => {
+    updateConfig((prev) => ({
+      ...prev,
+      portals: prev.portals.map((p) =>
+        p.id === id ? { ...p, rotationOffset: offset || undefined } : p
       ),
     }));
   };
@@ -135,8 +149,32 @@ export default function PortalTab({
             </button>
           ))}
         </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '8px' }}>
+          <label style={{ fontSize: '11px', color: '#666', whiteSpace: 'nowrap' }}>Offset:</label>
+          <div style={{ display: 'flex', gap: '4px', flex: 1 }}>
+            {[-45, 0, 45].map((offset) => (
+              <button
+                key={offset}
+                onClick={() => setPlacementRotationOffset(offset)}
+                style={{
+                  flex: 1,
+                  padding: '6px 0',
+                  background: placementRotationOffset === offset ? '#4a9eff' : '#333',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '4px',
+                  cursor: 'pointer',
+                  fontSize: '11px',
+                  fontWeight: placementRotationOffset === offset ? 'bold' : 'normal',
+                }}
+              >
+                {offset === 0 ? '0°' : `${offset > 0 ? '+' : ''}${offset}°`}
+              </button>
+            ))}
+          </div>
+        </div>
         <div style={{ fontSize: '10px', color: '#666', marginTop: '4px', textAlign: 'center' }}>
-          Rotation: {((DIRECTION_ROTATIONS[placementDirection] * 180) / Math.PI).toFixed(0)}°
+          Rotation: {((DIRECTION_ROTATIONS[placementDirection] * 180) / Math.PI + placementRotationOffset).toFixed(0)}°
         </div>
       </div>
 
@@ -205,7 +243,7 @@ export default function PortalTab({
                       {portal.label || portal.direction}
                     </span>
                     <span style={{ marginLeft: '8px', fontSize: '11px', color: '#888' }}>
-                      {portal.direction.toUpperCase()}
+                      {portal.direction.toUpperCase()}{portal.rotationOffset ? ` ${portal.rotationOffset > 0 ? '+' : ''}${portal.rotationOffset}°` : ''}
                     </span>
                   </div>
                   <button
@@ -295,6 +333,29 @@ export default function PortalTab({
                 </button>
               ))}
             </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px', marginTop: '6px' }}>
+              <label style={{ fontSize: '10px', color: '#666', whiteSpace: 'nowrap' }}>Offset:</label>
+              <div style={{ display: 'flex', gap: '3px', flex: 1 }}>
+                {[-45, 0, 45].map((offset) => (
+                  <button
+                    key={offset}
+                    onClick={() => updatePortalRotationOffset(selectedPortal.id, offset)}
+                    style={{
+                      flex: 1,
+                      padding: '5px 0',
+                      background: (selectedPortal.rotationOffset || 0) === offset ? '#4a9eff' : '#333',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '4px',
+                      cursor: 'pointer',
+                      fontSize: '10px',
+                    }}
+                  >
+                    {offset === 0 ? '0°' : `${offset > 0 ? '+' : ''}${offset}°`}
+                  </button>
+                ))}
+              </div>
+            </div>
           </div>
 
           {/* Position X */}
@@ -343,7 +404,7 @@ export default function PortalTab({
 
       {/* Instructions */}
       <div style={{ fontSize: '11px', color: '#666', marginTop: '8px' }}>
-        <p style={{ margin: '4px 0' }}>• Select a <b>Direction</b> (N/S/E/W) to set the portal rotation</p>
+        <p style={{ margin: '4px 0' }}>• Select a <b>Direction</b> (N/S/E/W) and optional <b>Offset</b> to set the portal rotation</p>
         <p style={{ margin: '4px 0' }}>• Click <b>Start Placement Mode</b> to enable click-to-place</p>
         <p style={{ margin: '4px 0' }}>• <b>Click in the scene</b> where you want to place the portal</p>
         <p style={{ margin: '4px 0' }}>• Click an existing portal to select and adjust its position</p>
@@ -424,6 +485,38 @@ export default function PortalTab({
                 </button>
               ))}
             </div>
+            <button
+              onClick={() =>
+                updateConfig((prev) => {
+                  const flip: Record<GateDirection, GateDirection> = {
+                    north: 'south',
+                    south: 'north',
+                    east: 'west',
+                    west: 'east',
+                  };
+                  return {
+                    ...prev,
+                    defaultSpawn: {
+                      ...prev.defaultSpawn!,
+                      direction: flip[prev.defaultSpawn!.direction],
+                    },
+                  };
+                })
+              }
+              style={{
+                width: '100%',
+                marginTop: '4px',
+                padding: '6px',
+                background: '#444',
+                color: 'white',
+                border: 'none',
+                borderRadius: '4px',
+                cursor: 'pointer',
+                fontSize: '11px',
+              }}
+            >
+              Rotate 180°
+            </button>
           </div>
 
           {/* Position X/Z */}

--- a/src/components/stage-editor/tabs/TextureTab.tsx
+++ b/src/components/stage-editor/tabs/TextureTab.tsx
@@ -405,15 +405,11 @@ export default function TextureTab({
                 <span>Repeat X</span>
                 <span style={{ color: '#4a9eff' }}>{repeatX.toFixed(1)}</span>
               </label>
-              <input
-                type="range"
-                min="0.1"
-                max="10"
-                step="0.1"
-                value={repeatX}
-                onChange={(e) => setRepeatX(Number(e.target.value))}
-                style={{ width: '100%' }}
-              />
+              <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
+                <button onClick={() => setRepeatX(Math.max(0.1, +(repeatX - 0.1).toFixed(1)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>-</button>
+                <input type="range" min="0.1" max="10" step="0.1" value={repeatX} onChange={(e) => setRepeatX(Number(e.target.value))} style={{ flex: 1 }} />
+                <button onClick={() => setRepeatX(Math.min(10, +(repeatX + 0.1).toFixed(1)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>+</button>
+              </div>
             </div>
 
             <div style={{ marginBottom: '16px' }}>
@@ -421,15 +417,11 @@ export default function TextureTab({
                 <span>Repeat Y</span>
                 <span style={{ color: '#4a9eff' }}>{repeatY.toFixed(1)}</span>
               </label>
-              <input
-                type="range"
-                min="0.1"
-                max="10"
-                step="0.1"
-                value={repeatY}
-                onChange={(e) => setRepeatY(Number(e.target.value))}
-                style={{ width: '100%' }}
-              />
+              <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
+                <button onClick={() => setRepeatY(Math.max(0.1, +(repeatY - 0.1).toFixed(1)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>-</button>
+                <input type="range" min="0.1" max="10" step="0.1" value={repeatY} onChange={(e) => setRepeatY(Number(e.target.value))} style={{ flex: 1 }} />
+                <button onClick={() => setRepeatY(Math.min(10, +(repeatY + 0.1).toFixed(1)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>+</button>
+              </div>
             </div>
 
             <div style={{ marginBottom: '16px' }}>
@@ -437,15 +429,11 @@ export default function TextureTab({
                 <span>Offset X</span>
                 <span style={{ color: '#4a9eff' }}>{offsetX.toFixed(2)}</span>
               </label>
-              <input
-                type="range"
-                min="-5"
-                max="5"
-                step="0.01"
-                value={offsetX}
-                onChange={(e) => setOffsetX(Number(e.target.value))}
-                style={{ width: '100%' }}
-              />
+              <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
+                <button onClick={() => setOffsetX(Math.max(-5, +(offsetX - 0.01).toFixed(2)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>-</button>
+                <input type="range" min="-5" max="5" step="0.01" value={offsetX} onChange={(e) => setOffsetX(Number(e.target.value))} style={{ flex: 1 }} />
+                <button onClick={() => setOffsetX(Math.min(5, +(offsetX + 0.01).toFixed(2)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>+</button>
+              </div>
             </div>
 
             <div style={{ marginBottom: '16px' }}>
@@ -453,15 +441,11 @@ export default function TextureTab({
                 <span>Offset Y</span>
                 <span style={{ color: '#4a9eff' }}>{offsetY.toFixed(2)}</span>
               </label>
-              <input
-                type="range"
-                min="-5"
-                max="5"
-                step="0.01"
-                value={offsetY}
-                onChange={(e) => setOffsetY(Number(e.target.value))}
-                style={{ width: '100%' }}
-              />
+              <div style={{ display: 'flex', gap: '4px', alignItems: 'center' }}>
+                <button onClick={() => setOffsetY(Math.max(-5, +(offsetY - 0.01).toFixed(2)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>-</button>
+                <input type="range" min="-5" max="5" step="0.01" value={offsetY} onChange={(e) => setOffsetY(Number(e.target.value))} style={{ flex: 1 }} />
+                <button onClick={() => setOffsetY(Math.min(5, +(offsetY + 0.01).toFixed(2)))} style={{ padding: '4px 8px', background: '#333', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontSize: '12px' }}>+</button>
+              </div>
             </div>
 
             {/* Wrap mode controls */}

--- a/src/components/stage-editor/types.ts
+++ b/src/components/stage-editor/types.ts
@@ -33,6 +33,7 @@ export interface PortalData {
   direction: GateDirection; // Label (north/south/east/west) AND determines rotation
   position: [number, number, number]; // x, y, z position in world space
   label: string;
+  rotationOffset?: number; // Additional rotation in degrees (e.g. 45, -45)
 }
 
 export interface SpawnPointData {
@@ -48,15 +49,24 @@ export const DIRECTION_ROTATIONS: Record<GateDirection, number> = {
   west: -Math.PI / 2,
 };
 
+// Get effective rotation for a portal (base direction + optional offset)
+export function getPortalRotation(portal: PortalData): number {
+  return DIRECTION_ROTATIONS[portal.direction] + ((portal.rotationOffset || 0) * Math.PI) / 180;
+}
+
 // =============== Texture Fixes ===============
 
+export type WrapMode = 'repeat' | 'mirror' | 'clamp';
+
 export interface TextureFix {
-  id: string;
-  meshPattern: string;
+  textureFile: string;
+  meshNames: string[];
   repeatX: number;
   repeatY: number;
   offsetX: number;
   offsetY: number;
+  wrapS?: WrapMode;
+  wrapT?: WrapMode;
 }
 
 // =============== Collision Obstacles ===============


### PR DESCRIPTION
## Summary
- Portal placement now supports an optional rotation offset (-45° / 0° / +45°) on top of the base N/S/E/W direction, for stages that need angled portals
- `PortalData.rotationOffset` is an optional field (degrees) — only saved when non-zero
- `getPortalRotation()` helper computes effective rotation (base + offset) used by overlay rendering and GLB export
- Minor UX tweaks: obstacle rotation step 15° → 5°, texture repeat sliders get +/- buttons, export includes texture fixes from global settings

## Test plan
- [ ] Open stage editor, go to Portals tab
- [ ] Verify N/S/E/W direction buttons still work as before
- [ ] Select a direction, set offset to +45° or -45°, place a portal — verify preview and placed portal are rotated correctly
- [ ] Select an existing portal, change its offset in the editor panel — verify it updates in the 3D view
- [ ] Export a GLB with an offset portal — verify spawn/trigger markers are positioned along the angled direction

🤖 Generated with [Claude Code](https://claude.com/claude-code)