### PR TITLE
Add stage object placement to quest editor

### DIFF
--- a/src/components/elements/AreaWarp.tsx
+++ b/src/components/elements/AreaWarp.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useGLTF } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ElementProps, StoryMeta } from './types';
 
@@ -20,6 +21,10 @@ export const areaWarpMeta: StoryMeta = {
   defaultState: 'active',
 };
 
+// Animated warp surface texture
+const WARP_TEXTURE_NAME = 'o0s_1_fwarp2';
+const WARP_SCROLL_SPEED = 1.35;
+
 export default function AreaWarp({
   position = [0, 0, 0],
   rotation = [0, 0, 0],
@@ -28,9 +33,11 @@ export default function AreaWarp({
 }: AreaWarpProps) {
   const { scene } = useGLTF('/objects/special_z/o0s_warpm.imd/o0s_warpm.glb');
   const clonedScene = useMemo(() => scene.clone(), [scene]);
+  const warpTexturesRef = useRef<THREE.Texture[]>([]);
 
   // Apply texture settings and state-based effects
   useEffect(() => {
+    const warpTextures: THREE.Texture[] = [];
     clonedScene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
         const materials = Array.isArray(child.material) ? child.material : [child.material];
@@ -39,7 +46,15 @@ export default function AreaWarp({
             if (mat.map) {
               mat.map.wrapS = THREE.MirroredRepeatWrapping;
               mat.map.wrapT = THREE.MirroredRepeatWrapping;
-              mat.map.needsUpdate = true;
+
+              if (mat.map.name?.includes(WARP_TEXTURE_NAME)) {
+                // Animated warp surface — offsetY depends on state
+                mat.map.offset.set(0, state === 'active' ? 1.34 : 0);
+                mat.map.needsUpdate = true;
+                warpTextures.push(mat.map);
+              } else {
+                mat.map.needsUpdate = true;
+              }
             }
             // Dim the material when inactive
             if (state === 'inactive') {
@@ -54,7 +69,16 @@ export default function AreaWarp({
         });
       }
     });
+    warpTexturesRef.current = warpTextures;
   }, [clonedScene, state]);
+
+  // Animate warp texture scroll on offset.x
+  useFrame((_, delta) => {
+    warpTexturesRef.current.forEach((tex) => {
+      tex.offset.x -= WARP_SCROLL_SPEED * delta;
+      if (tex.offset.x < -10) tex.offset.x += 10;
+    });
+  });
 
   return (
     <group position={position} rotation={rotation} scale={scale}>

--- a/src/components/elements/Fence.tsx
+++ b/src/components/elements/Fence.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useGLTF, Box } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ElementProps, StoryMeta } from './types';
 
@@ -23,6 +24,7 @@ export const fenceMeta: StoryMeta = {
 
 // The laser texture - meshes with this texture are hidden when disabled
 const LASER_TEXTURE_NAME = 'o0c_1_fence2';
+const LASER_SCROLL_SPEED = 0.70;
 
 const FENCE_MODELS: Record<string, string> = {
   default: '/objects/01_o01a/o0c_fence.imd/o0c_fence.glb',
@@ -40,9 +42,11 @@ export default function Fence({
   const modelPath = FENCE_MODELS[variant] || FENCE_MODELS.default;
   const { scene } = useGLTF(modelPath);
   const clonedScene = useMemo(() => scene.clone(), [scene]);
+  const laserTexturesRef = useRef<THREE.Texture[]>([]);
 
-  // Hide laser mesh when disabled, keep poles visible
+  // Hide laser mesh when disabled, keep poles visible, collect laser textures
   useEffect(() => {
+    const laserTextures: THREE.Texture[] = [];
     clonedScene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
         const materials = Array.isArray(child.material) ? child.material : [child.material];
@@ -55,13 +59,29 @@ export default function Fence({
           return false;
         });
 
-        // Hide laser meshes when disabled
+        // Hide laser meshes when disabled, collect textures for scroll
         if (hasLaserTexture) {
           child.visible = state === 'active';
+          materials.forEach((mat) => {
+            if ((mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshBasicMaterial) && mat.map) {
+              if (mat.map.name?.includes(LASER_TEXTURE_NAME)) {
+                laserTextures.push(mat.map);
+              }
+            }
+          });
         }
       }
     });
+    laserTexturesRef.current = laserTextures;
   }, [clonedScene, state]);
+
+  // Animate laser texture scroll on offset.x
+  useFrame((_, delta) => {
+    laserTexturesRef.current.forEach((tex) => {
+      tex.offset.x -= LASER_SCROLL_SPEED * delta;
+      if (tex.offset.x < -10) tex.offset.x += 10;
+    });
+  });
 
   // Calculate bounding box for collision indicator
   const bounds = useMemo(() => {

--- a/src/components/elements/Fence4.tsx
+++ b/src/components/elements/Fence4.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useGLTF, Box } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ElementProps, StoryMeta } from './types';
 
@@ -22,6 +23,7 @@ export const fence4Meta: StoryMeta = {
 
 // The laser texture - meshes with this texture are hidden when disabled
 const LASER_TEXTURE_NAME = 'o0c_1_fence2';
+const LASER_SCROLL_SPEED = 0.70;
 
 export default function Fence4({
   position = [0, 0, 0],
@@ -31,9 +33,11 @@ export default function Fence4({
 }: Fence4Props) {
   const { scene } = useGLTF('/objects/01_o01a/o0c_fence4.imd/o0c_fence4.glb');
   const clonedScene = useMemo(() => scene.clone(), [scene]);
+  const laserTexturesRef = useRef<THREE.Texture[]>([]);
 
-  // Hide laser mesh when disabled, keep poles visible
+  // Hide laser mesh when disabled, keep poles visible, collect laser textures
   useEffect(() => {
+    const laserTextures: THREE.Texture[] = [];
     clonedScene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
         const materials = Array.isArray(child.material) ? child.material : [child.material];
@@ -46,13 +50,29 @@ export default function Fence4({
           return false;
         });
 
-        // Hide laser meshes when disabled
+        // Hide laser meshes when disabled, collect textures for scroll
         if (hasLaserTexture) {
           child.visible = state === 'active';
+          materials.forEach((mat) => {
+            if ((mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshBasicMaterial) && mat.map) {
+              if (mat.map.name?.includes(LASER_TEXTURE_NAME)) {
+                laserTextures.push(mat.map);
+              }
+            }
+          });
         }
       }
     });
+    laserTexturesRef.current = laserTextures;
   }, [clonedScene, state]);
+
+  // Animate laser texture scroll on offset.x
+  useFrame((_, delta) => {
+    laserTexturesRef.current.forEach((tex) => {
+      tex.offset.x -= LASER_SCROLL_SPEED * delta;
+      if (tex.offset.x < -10) tex.offset.x += 10;
+    });
+  });
 
   // Calculate bounding box for collision indicator
   const bounds = useMemo(() => {

--- a/src/components/elements/Gate.tsx
+++ b/src/components/elements/Gate.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useGLTF, Box } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ElementProps, StoryMeta } from './types';
 
@@ -23,15 +24,13 @@ export const gateMeta: StoryMeta = {
 // The laser/beam mesh that gets hidden when open
 const LASER_MESH_NAME = 'o0c_gate_3';
 
-// Texture config for proper display
-const TEXTURE_CONFIG = {
-  'o0c_0_gatet.png': {
-    offsetX: 0.56,
-    offsetY: 0.8,
-    repeatX: 1,
-    repeatY: 2,
-  },
-};
+// Laser scroll speed (units/sec on offset.x)
+const LASER_SCROLL_SPEED = 0.40;
+
+// Texture to use for all submeshes (rails + laser sheet)
+const UNIFIED_TEXTURE_NAME = 'o0c_1_gate';
+// Texture to replace (switch icon part — should use o0c_1_gate instead)
+const REPLACED_TEXTURE_NAME = 'o0c_0_gatet';
 
 export default function Gate({
   position = [0, 0, 0],
@@ -41,34 +40,61 @@ export default function Gate({
 }: GateProps) {
   const { scene } = useGLTF('/objects/01_o01a/o0c_gate.imd/o0c_gate.glb');
   const clonedScene = useMemo(() => scene.clone(), [scene]);
+  const laserTexturesRef = useRef<THREE.Texture[]>([]);
 
-  // Toggle laser mesh visibility and apply texture settings
+  // Toggle laser mesh visibility, swap textures, collect laser refs
   useEffect(() => {
-    clonedScene.traverse((child) => {
-      // Hide/show laser mesh based on state
-      if (child.name === LASER_MESH_NAME) {
-        child.visible = state === 'closed';
-      }
+    const laserTextures: THREE.Texture[] = [];
 
-      // Apply texture settings
+    // First pass: find the o0c_1_gate texture
+    let unifiedTexture: THREE.Texture | null = null;
+    clonedScene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
         const materials = Array.isArray(child.material) ? child.material : [child.material];
         materials.forEach((mat) => {
           if ((mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshBasicMaterial) && mat.map) {
-            const texName = mat.map.name || '';
-            const config = TEXTURE_CONFIG[texName as keyof typeof TEXTURE_CONFIG];
-            if (config) {
-              mat.map.offset.set(config.offsetX, config.offsetY);
-              mat.map.repeat.set(config.repeatX, config.repeatY);
-              mat.map.wrapS = THREE.RepeatWrapping;
-              mat.map.wrapT = THREE.RepeatWrapping;
-              mat.map.needsUpdate = true;
+            if (mat.map.name?.includes(UNIFIED_TEXTURE_NAME)) {
+              unifiedTexture = mat.map;
             }
           }
         });
       }
     });
+
+    // Second pass: swap replaced texture, hide/show laser, collect refs
+    clonedScene.traverse((child) => {
+      if (child.name === LASER_MESH_NAME) {
+        child.visible = state === 'closed';
+      }
+
+      if (child instanceof THREE.Mesh) {
+        const isLaser = child.name === LASER_MESH_NAME;
+        const materials = Array.isArray(child.material) ? child.material : [child.material];
+        materials.forEach((mat) => {
+          if ((mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshBasicMaterial) && mat.map) {
+            // Make frame mesh gray to distinguish from laser
+            if (mat.map.name?.includes(REPLACED_TEXTURE_NAME)) {
+              mat.map = null;
+              (mat as THREE.MeshStandardMaterial).color = new THREE.Color(0.5, 0.5, 0.5);
+              mat.needsUpdate = true;
+            }
+            if (isLaser) {
+              laserTextures.push(mat.map);
+            }
+          }
+        });
+      }
+    });
+    laserTexturesRef.current = laserTextures;
   }, [clonedScene, state]);
+
+  // Animate laser texture scroll on offset.x
+  useFrame((_, delta) => {
+    laserTexturesRef.current.forEach((tex) => {
+      tex.offset.x -= LASER_SCROLL_SPEED * delta;
+      if (tex.offset.x < -10) tex.offset.x += 10;
+    });
+  });
 
   // Calculate bounding box for collision indicator
   const bounds = useMemo(() => {

--- a/src/components/elements/KeyGate.tsx
+++ b/src/components/elements/KeyGate.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useGLTF, Box } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ElementProps, StoryMeta } from './types';
 
@@ -23,15 +24,9 @@ export const keyGateMeta: StoryMeta = {
 // The laser/beam mesh that gets hidden when open
 const LASER_MESH_NAME = 'o0c_gatet_3';
 
-// Texture config for proper display
-const TEXTURE_CONFIG = {
-  'o0c_0_gatet.png': {
-    offsetX: 0.56,
-    offsetY: 0.8,
-    repeatX: 1,
-    repeatY: 2,
-  },
-};
+// Laser scroll speed (units/sec on offset.x)
+const LASER_SCROLL_SPEED = 0.40;
+
 
 export default function KeyGate({
   position = [0, 0, 0],
@@ -41,34 +36,47 @@ export default function KeyGate({
 }: KeyGateProps) {
   const { scene } = useGLTF('/objects/01_o01a/o0c_gatet.imd/o0c_gatet.glb');
   const clonedScene = useMemo(() => scene.clone(), [scene]);
+  const laserTexturesRef = useRef<THREE.Texture[]>([]);
 
-  // Toggle laser mesh visibility and apply texture settings
+  // Toggle laser visibility, make frame gray, keep terminal texture
   useEffect(() => {
+    const laserTextures: THREE.Texture[] = [];
+
     clonedScene.traverse((child) => {
-      // Hide/show laser mesh based on state
       if (child.name === LASER_MESH_NAME) {
         child.visible = state === 'closed';
       }
 
-      // Apply texture settings
       if (child instanceof THREE.Mesh) {
+        const isLaser = child.name === LASER_MESH_NAME;
         const materials = Array.isArray(child.material) ? child.material : [child.material];
         materials.forEach((mat) => {
-          if ((mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshBasicMaterial) && mat.map) {
-            const texName = mat.map.name || '';
-            const config = TEXTURE_CONFIG[texName as keyof typeof TEXTURE_CONFIG];
-            if (config) {
-              mat.map.offset.set(config.offsetX, config.offsetY);
-              mat.map.repeat.set(config.repeatX, config.repeatY);
-              mat.map.wrapS = THREE.RepeatWrapping;
-              mat.map.wrapT = THREE.RepeatWrapping;
-              mat.map.needsUpdate = true;
-            }
+          if (!(mat instanceof THREE.MeshStandardMaterial || mat instanceof THREE.MeshBasicMaterial)) return;
+          if (!mat.map) return;
+
+          if (!isLaser) {
+            // Non-laser meshes → solid gray
+            mat.map = null;
+            (mat as THREE.MeshStandardMaterial).color = new THREE.Color(0.5, 0.5, 0.5);
+            mat.needsUpdate = true;
+          }
+
+          if (isLaser && mat.map) {
+            laserTextures.push(mat.map);
           }
         });
       }
     });
+    laserTexturesRef.current = laserTextures;
   }, [clonedScene, state]);
+
+  // Animate laser texture scroll on offset.x
+  useFrame((_, delta) => {
+    laserTexturesRef.current.forEach((tex) => {
+      tex.offset.x -= LASER_SCROLL_SPEED * delta;
+      if (tex.offset.x < -10) tex.offset.x += 10;
+    });
+  });
 
   // Calculate bounding box for collision indicator
   const bounds = useMemo(() => {

--- a/src/components/elements/StartWarp.tsx
+++ b/src/components/elements/StartWarp.tsx
@@ -1,5 +1,6 @@
-import { useMemo, useEffect } from 'react';
+import { useMemo, useEffect, useRef } from 'react';
 import { useGLTF } from '@react-three/drei';
+import { useFrame } from '@react-three/fiber';
 import * as THREE from 'three';
 import type { ElementProps, StoryMeta } from './types';
 
@@ -20,6 +21,10 @@ export const startWarpMeta: StoryMeta = {
   defaultState: 'active',
 };
 
+// Animated warp surface texture
+const WARP_TEXTURE_NAME = 'o0s_1_swarp3';
+const WARP_SCROLL_SPEED = 1.35;
+
 export default function StartWarp({
   position = [0, 0, 0],
   rotation = [0, 0, 0],
@@ -28,9 +33,11 @@ export default function StartWarp({
 }: StartWarpProps) {
   const { scene } = useGLTF('/objects/special_z/o0s_warps.imd/o0s_warps.glb');
   const clonedScene = useMemo(() => scene.clone(), [scene]);
+  const warpTexturesRef = useRef<THREE.Texture[]>([]);
 
   // Apply texture settings and state-based effects
   useEffect(() => {
+    const warpTextures: THREE.Texture[] = [];
     clonedScene.traverse((child) => {
       if (child instanceof THREE.Mesh) {
         const materials = Array.isArray(child.material) ? child.material : [child.material];
@@ -39,7 +46,13 @@ export default function StartWarp({
             if (mat.map) {
               mat.map.wrapS = THREE.MirroredRepeatWrapping;
               mat.map.wrapT = THREE.MirroredRepeatWrapping;
-              mat.map.needsUpdate = true;
+
+              if (mat.map.name?.includes(WARP_TEXTURE_NAME)) {
+                mat.map.needsUpdate = true;
+                warpTextures.push(mat.map);
+              } else {
+                mat.map.needsUpdate = true;
+              }
             }
             // Dim the material when inactive
             if (state === 'inactive') {
@@ -54,7 +67,16 @@ export default function StartWarp({
         });
       }
     });
+    warpTexturesRef.current = warpTextures;
   }, [clonedScene, state]);
+
+  // Animate warp texture scroll on offset.y
+  useFrame((_, delta) => {
+    warpTexturesRef.current.forEach((tex) => {
+      tex.offset.y -= WARP_SCROLL_SPEED * delta;
+      if (tex.offset.y < -10) tex.offset.y += 10;
+    });
+  });
 
   return (
     <group position={position} rotation={rotation} scale={scale}>

--- a/src/components/quest-editor/QuestEditor.tsx
+++ b/src/components/quest-editor/QuestEditor.tsx
@@ -18,7 +18,7 @@ type TabId = 'layout' | 'content' | 'metadata' | 'export';
 const TABS: { id: TabId; label: string; disabled?: boolean }[] = [
   { id: 'layout', label: 'Layout' },
   { id: 'content', label: 'Content' },
-  { id: 'metadata', label: 'Metadata', disabled: true },
+  { id: 'metadata', label: 'Metadata' },
   { id: 'export', label: 'Export' },
 ];
 
@@ -359,7 +359,7 @@ export default function QuestEditor() {
           <LayoutTab project={project} onUpdateProject={updateProject} />
         )}
         {activeTab === 'content' && <ContentTab project={project} onUpdateProject={updateProject} />}
-        {activeTab === 'metadata' && <MetadataTab />}
+        {activeTab === 'metadata' && <MetadataTab project={project} onUpdateProject={updateProject} />}
         {activeTab === 'export' && <ExportTab project={project} setProject={setProject} />}
       </div>
     </div>

--- a/src/components/quest-editor/QuestEditor.tsx
+++ b/src/components/quest-editor/QuestEditor.tsx
@@ -1,0 +1,367 @@
+/**
+ * QuestEditor — Main component with tab shell and header controls
+ *
+ * Milestone 1: Grid Layout Editor
+ */
+
+import { useState, useCallback } from 'react';
+import type { QuestProject } from './types';
+import { EDITOR_AREAS } from './types';
+import { useQuestProject } from './hooks/useQuestProject';
+import LayoutTab from './tabs/LayoutTab';
+import ContentTab from './tabs/ContentTab';
+import MetadataTab from './tabs/MetadataTab';
+import ExportTab from './tabs/ExportTab';
+
+type TabId = 'layout' | 'content' | 'metadata' | 'export';
+
+const TABS: { id: TabId; label: string; disabled?: boolean }[] = [
+  { id: 'layout', label: 'Layout' },
+  { id: 'content', label: 'Content' },
+  { id: 'metadata', label: 'Metadata', disabled: true },
+  { id: 'export', label: 'Export' },
+];
+
+export default function QuestEditor() {
+  const {
+    project,
+    updateProject,
+    setProject,
+    undo,
+    redo,
+    canUndo,
+    canRedo,
+    newProject,
+    savedProjectIds,
+    loadProject,
+    deleteProject,
+    getSavedProject,
+  } = useQuestProject();
+
+  const [activeTab, setActiveTab] = useState<TabId>('layout');
+  const [showProjectMenu, setShowProjectMenu] = useState(false);
+
+  const availableAreas = EDITOR_AREAS.filter(a => a.available);
+
+  const handleAreaChange = useCallback((areaKey: string) => {
+    updateProject(prev => ({
+      ...prev,
+      areaKey,
+      cells: {},
+      startPos: null,
+      endPos: null,
+      keyLinks: {},
+    }));
+  }, [updateProject]);
+
+  const handleVariantChange = useCallback((variant: string) => {
+    updateProject(prev => ({
+      ...prev,
+      variant,
+      cells: {},
+      startPos: null,
+      endPos: null,
+      keyLinks: {},
+    }));
+  }, [updateProject]);
+
+  const handleGridSizeChange = useCallback((gridSize: number) => {
+    updateProject(prev => ({
+      ...prev,
+      gridSize,
+      cells: {},
+      startPos: null,
+      endPos: null,
+      keyLinks: {},
+    }));
+  }, [updateProject]);
+
+  const handleNameChange = useCallback((name: string) => {
+    updateProject(prev => ({ ...prev, name }));
+  }, [updateProject]);
+
+  const currentArea = EDITOR_AREAS.find(a => a.key === project.areaKey);
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      height: '100vh',
+      background: '#1a1a2e',
+      color: '#fff',
+      fontFamily: "'Segoe UI', system-ui, sans-serif",
+    }}>
+      {/* Header */}
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        padding: '10px 16px',
+        background: '#151525',
+        borderBottom: '1px solid #333',
+        flexWrap: 'wrap',
+      }}>
+        {/* Back link */}
+        <a
+          href="/"
+          style={{
+            color: '#88aaff',
+            textDecoration: 'none',
+            fontSize: '13px',
+            marginRight: '4px',
+          }}
+        >
+          ← Home
+        </a>
+
+        {/* Project name */}
+        <input
+          type="text"
+          value={project.name}
+          onChange={(e) => handleNameChange(e.target.value)}
+          style={{
+            background: 'transparent',
+            border: '1px solid transparent',
+            borderRadius: '4px',
+            color: '#fff',
+            fontSize: '15px',
+            fontWeight: 700,
+            padding: '4px 8px',
+            width: '200px',
+          }}
+          onFocus={(e) => e.currentTarget.style.borderColor = '#444'}
+          onBlur={(e) => e.currentTarget.style.borderColor = 'transparent'}
+        />
+
+        {/* Separator */}
+        <div style={{ width: '1px', height: '24px', background: '#333' }} />
+
+        {/* Area selector */}
+        <select
+          value={project.areaKey}
+          onChange={(e) => handleAreaChange(e.target.value)}
+          style={{
+            padding: '6px 10px',
+            background: '#2a2a4a',
+            border: '1px solid #444',
+            borderRadius: '4px',
+            color: '#fff',
+            fontSize: '12px',
+          }}
+        >
+          {EDITOR_AREAS.map(area => (
+            <option key={area.key} value={area.key} disabled={!area.available}>
+              {area.name} ({area.prefix}){!area.available ? ' — no config' : ''}
+            </option>
+          ))}
+        </select>
+
+        {/* Variant selector */}
+        {currentArea && currentArea.variants.length > 0 && (
+          <select
+            value={project.variant}
+            onChange={(e) => handleVariantChange(e.target.value)}
+            style={{
+              padding: '6px 10px',
+              background: '#2a2a4a',
+              border: '1px solid #444',
+              borderRadius: '4px',
+              color: '#fff',
+              fontSize: '12px',
+            }}
+          >
+            {currentArea.variants.map(v => (
+              <option key={v} value={v}>Variant {v.toUpperCase()}</option>
+            ))}
+          </select>
+        )}
+
+        {/* Grid size */}
+        <select
+          value={project.gridSize}
+          onChange={(e) => handleGridSizeChange(parseInt(e.target.value))}
+          style={{
+            padding: '6px 10px',
+            background: '#2a2a4a',
+            border: '1px solid #444',
+            borderRadius: '4px',
+            color: '#fff',
+            fontSize: '12px',
+          }}
+        >
+          {[3, 4, 5, 6, 7].map(n => (
+            <option key={n} value={n}>{n}x{n}</option>
+          ))}
+        </select>
+
+        <div style={{ flex: 1 }} />
+
+        {/* Undo/Redo */}
+        <button
+          onClick={undo}
+          disabled={!canUndo}
+          title="Undo (Ctrl+Z)"
+          style={{
+            padding: '4px 10px',
+            background: canUndo ? '#2a2a4a' : '#222',
+            border: '1px solid #444',
+            borderRadius: '4px',
+            color: canUndo ? '#fff' : '#555',
+            fontSize: '12px',
+            cursor: canUndo ? 'pointer' : 'default',
+          }}
+        >
+          Undo
+        </button>
+        <button
+          onClick={redo}
+          disabled={!canRedo}
+          title="Redo (Ctrl+Y)"
+          style={{
+            padding: '4px 10px',
+            background: canRedo ? '#2a2a4a' : '#222',
+            border: '1px solid #444',
+            borderRadius: '4px',
+            color: canRedo ? '#fff' : '#555',
+            fontSize: '12px',
+            cursor: canRedo ? 'pointer' : 'default',
+          }}
+        >
+          Redo
+        </button>
+
+        {/* Project menu */}
+        <div style={{ position: 'relative' }}>
+          <button
+            onClick={() => setShowProjectMenu(!showProjectMenu)}
+            style={{
+              padding: '4px 10px',
+              background: '#2a2a4a',
+              border: '1px solid #444',
+              borderRadius: '4px',
+              color: '#fff',
+              fontSize: '12px',
+              cursor: 'pointer',
+            }}
+          >
+            Projects
+          </button>
+          {showProjectMenu && (
+            <div
+              style={{
+                position: 'absolute',
+                top: '100%',
+                right: 0,
+                marginTop: '4px',
+                background: '#1a1a2e',
+                border: '1px solid #444',
+                borderRadius: '8px',
+                padding: '8px',
+                width: '260px',
+                zIndex: 100,
+                boxShadow: '0 8px 24px rgba(0,0,0,0.5)',
+              }}
+            >
+              <button
+                onClick={() => { newProject(); setShowProjectMenu(false); }}
+                style={{
+                  width: '100%', padding: '8px', background: '#448844',
+                  border: 'none', borderRadius: '4px', color: '#fff',
+                  fontSize: '12px', cursor: 'pointer', marginBottom: '8px',
+                }}
+              >
+                New Project
+              </button>
+              {savedProjectIds.length === 0 && (
+                <div style={{ color: '#888', fontSize: '12px', padding: '8px' }}>
+                  No saved projects
+                </div>
+              )}
+              {savedProjectIds.map(id => {
+                const saved = getSavedProject(id);
+                if (!saved) return null;
+                const isCurrent = id === project.id;
+                return (
+                  <div
+                    key={id}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: '8px',
+                      padding: '6px 8px',
+                      borderRadius: '4px',
+                      background: isCurrent ? '#333366' : 'transparent',
+                      marginBottom: '2px',
+                    }}
+                  >
+                    <div
+                      style={{ flex: 1, cursor: 'pointer', fontSize: '12px', color: '#fff' }}
+                      onClick={() => { loadProject(id); setShowProjectMenu(false); }}
+                    >
+                      {saved.name}
+                      <div style={{ fontSize: '10px', color: '#888' }}>
+                        {saved.areaKey}-{saved.variant} | {Object.keys(saved.cells).length} cells
+                      </div>
+                    </div>
+                    {!isCurrent && (
+                      <button
+                        onClick={() => deleteProject(id)}
+                        style={{
+                          background: 'none', border: 'none', color: '#884444',
+                          fontSize: '14px', cursor: 'pointer', padding: '2px',
+                        }}
+                        title="Delete project"
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Tab bar */}
+      <div style={{
+        display: 'flex',
+        gap: '0',
+        background: '#151525',
+        borderBottom: '1px solid #333',
+      }}>
+        {TABS.map(tab => (
+          <button
+            key={tab.id}
+            onClick={() => !tab.disabled && setActiveTab(tab.id)}
+            disabled={tab.disabled}
+            style={{
+              padding: '10px 20px',
+              background: activeTab === tab.id ? '#1a1a2e' : 'transparent',
+              border: 'none',
+              borderBottom: activeTab === tab.id ? '2px solid #5588ff' : '2px solid transparent',
+              color: tab.disabled ? '#555' : activeTab === tab.id ? '#fff' : '#888',
+              fontSize: '13px',
+              fontWeight: activeTab === tab.id ? 600 : 400,
+              cursor: tab.disabled ? 'default' : 'pointer',
+              transition: 'all 0.1s',
+            }}
+          >
+            {tab.label}
+            {tab.disabled && <span style={{ fontSize: '10px', marginLeft: '4px' }}>(M{tab.id === 'content' ? '2' : '3'})</span>}
+          </button>
+        ))}
+      </div>
+
+      {/* Active tab content */}
+      <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
+        {activeTab === 'layout' && (
+          <LayoutTab project={project} onUpdateProject={updateProject} />
+        )}
+        {activeTab === 'content' && <ContentTab project={project} onUpdateProject={updateProject} />}
+        {activeTab === 'metadata' && <MetadataTab />}
+        {activeTab === 'export' && <ExportTab project={project} setProject={setProject} />}
+      </div>
+    </div>
+  );
+}

--- a/src/components/quest-editor/hooks/useQuestProject.ts
+++ b/src/components/quest-editor/hooks/useQuestProject.ts
@@ -1,0 +1,237 @@
+/**
+ * useQuestProject — localStorage persistence with undo/redo
+ *
+ * Adapted from useStageConfig pattern. Manages QuestProject state
+ * with debounced auto-save and keyboard shortcuts.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import type { QuestProject } from '../types';
+import { createDefaultProject } from '../types';
+
+const STORAGE_KEY = 'quest-editor-projects';
+const MAX_UNDO_STACK = 50;
+
+// ============================================================================
+// localStorage helpers
+// ============================================================================
+
+const isBrowser = typeof window !== 'undefined';
+
+function loadAllProjects(): Record<string, QuestProject> {
+  if (!isBrowser) return {};
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch {
+    return {};
+  }
+}
+
+function saveAllProjects(projects: Record<string, QuestProject>) {
+  if (!isBrowser) return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(projects));
+  } catch (e) {
+    console.error('Failed to save quest projects:', e);
+  }
+}
+
+function cloneProject(project: QuestProject): QuestProject {
+  return JSON.parse(JSON.stringify(project));
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export interface UseQuestProjectReturn {
+  project: QuestProject;
+  updateProject: (updater: (prev: QuestProject) => QuestProject) => void;
+  setProject: (project: QuestProject) => void;
+  undo: () => void;
+  redo: () => void;
+  canUndo: boolean;
+  canRedo: boolean;
+  saveNow: () => void;
+  loadProject: (id: string) => void;
+  deleteProject: (id: string) => void;
+  newProject: () => void;
+  savedProjectIds: string[];
+  getSavedProject: (id: string) => QuestProject | null;
+}
+
+export function useQuestProject(): UseQuestProjectReturn {
+  const [project, setProjectState] = useState<QuestProject>(() => {
+    if (!isBrowser) return createDefaultProject();
+    // Try to load last active project
+    const projects = loadAllProjects();
+    const lastId = localStorage.getItem('quest-editor-active');
+    if (lastId && projects[lastId]) return projects[lastId];
+    // Return first saved or create new
+    const ids = Object.keys(projects);
+    if (ids.length > 0) return projects[ids[0]];
+    return createDefaultProject();
+  });
+  const [undoStack, setUndoStack] = useState<QuestProject[]>([]);
+  const [redoStack, setRedoStack] = useState<QuestProject[]>([]);
+  const [isDirty, setIsDirty] = useState(false);
+  const [savedIds, setSavedIds] = useState<string[]>(() => Object.keys(loadAllProjects()));
+
+  // Track active project ID
+  useEffect(() => {
+    if (isBrowser) localStorage.setItem('quest-editor-active', project.id);
+  }, [project.id]);
+
+  // Auto-save when dirty (500ms debounce)
+  useEffect(() => {
+    if (!isDirty) return;
+
+    const timeout = setTimeout(() => {
+      const projects = loadAllProjects();
+      projects[project.id] = { ...project, lastModified: new Date().toISOString() };
+      saveAllProjects(projects);
+      setSavedIds(Object.keys(projects));
+      setIsDirty(false);
+    }, 500);
+
+    return () => clearTimeout(timeout);
+  }, [project, isDirty]);
+
+  // Keyboard shortcuts: Ctrl+Z / Ctrl+Y
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault();
+        undo();
+      }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
+        e.preventDefault();
+        redo();
+      }
+    }
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [undoStack, redoStack]);
+
+  const updateProject = useCallback(
+    (updater: (prev: QuestProject) => QuestProject) => {
+      setProjectState((prev) => {
+        setUndoStack((stack) => {
+          const newStack = [...stack, cloneProject(prev)];
+          return newStack.length > MAX_UNDO_STACK ? newStack.slice(-MAX_UNDO_STACK) : newStack;
+        });
+        setRedoStack([]);
+        setIsDirty(true);
+        return updater(prev);
+      });
+    },
+    []
+  );
+
+  const setProject = useCallback((newProject: QuestProject) => {
+    setProjectState((prev) => {
+      setUndoStack((stack) => {
+        const newStack = [...stack, cloneProject(prev)];
+        return newStack.length > MAX_UNDO_STACK ? newStack.slice(-MAX_UNDO_STACK) : newStack;
+      });
+      setRedoStack([]);
+      setIsDirty(true);
+      return newProject;
+    });
+  }, []);
+
+  const undo = useCallback(() => {
+    if (undoStack.length === 0) return;
+    const prev = undoStack[undoStack.length - 1];
+    setUndoStack((stack) => stack.slice(0, -1));
+    setProjectState((current) => {
+      setRedoStack((stack) => [...stack, cloneProject(current)]);
+      setIsDirty(true);
+      return prev;
+    });
+  }, [undoStack]);
+
+  const redo = useCallback(() => {
+    if (redoStack.length === 0) return;
+    const next = redoStack[redoStack.length - 1];
+    setRedoStack((stack) => stack.slice(0, -1));
+    setProjectState((current) => {
+      setUndoStack((stack) => [...stack, cloneProject(current)]);
+      setIsDirty(true);
+      return next;
+    });
+  }, [redoStack]);
+
+  const saveNow = useCallback(() => {
+    const projects = loadAllProjects();
+    projects[project.id] = { ...project, lastModified: new Date().toISOString() };
+    saveAllProjects(projects);
+    setSavedIds(Object.keys(projects));
+    setIsDirty(false);
+  }, [project]);
+
+  const loadProject = useCallback((id: string) => {
+    const projects = loadAllProjects();
+    if (projects[id]) {
+      setProjectState(projects[id]);
+      setUndoStack([]);
+      setRedoStack([]);
+      setIsDirty(false);
+    }
+  }, []);
+
+  const deleteProject = useCallback((id: string) => {
+    const projects = loadAllProjects();
+    delete projects[id];
+    saveAllProjects(projects);
+    setSavedIds(Object.keys(projects));
+    // If we deleted the active project, create a new one
+    if (id === project.id) {
+      const remaining = Object.keys(projects);
+      if (remaining.length > 0) {
+        setProjectState(projects[remaining[0]]);
+      } else {
+        setProjectState(createDefaultProject());
+      }
+      setUndoStack([]);
+      setRedoStack([]);
+      setIsDirty(false);
+    }
+  }, [project.id]);
+
+  const newProject = useCallback(() => {
+    // Save current project first
+    const projects = loadAllProjects();
+    projects[project.id] = { ...project, lastModified: new Date().toISOString() };
+    saveAllProjects(projects);
+    // Create new
+    const fresh = createDefaultProject();
+    setProjectState(fresh);
+    setUndoStack([]);
+    setRedoStack([]);
+    setIsDirty(true);
+    setSavedIds(Object.keys(projects));
+  }, [project]);
+
+  const getSavedProject = useCallback((id: string): QuestProject | null => {
+    const projects = loadAllProjects();
+    return projects[id] || null;
+  }, []);
+
+  return {
+    project,
+    updateProject,
+    setProject,
+    undo,
+    redo,
+    canUndo: undoStack.length > 0,
+    canRedo: redoStack.length > 0,
+    saveNow,
+    loadProject,
+    deleteProject,
+    newProject,
+    savedProjectIds: savedIds,
+    getSavedProject,
+  };
+}

--- a/src/components/quest-editor/hooks/useStageConfigs.ts
+++ b/src/components/quest-editor/hooks/useStageConfigs.ts
@@ -1,0 +1,126 @@
+/**
+ * useStageConfigs — Loads stage configs and provides gate helpers
+ *
+ * Uses paru-configs.json which contains 186 stages across s01-s05.
+ * Provides filtering by area/variant and rotation-aware gate matching.
+ */
+
+import { useMemo } from 'react';
+import paruConfigs from '../../../../docs/paru-configs.json';
+import type { StageConfig } from '../../../systems/stage/types';
+import type { Direction } from '../types';
+import { EDITOR_AREAS } from '../types';
+
+// Cast the JSON import
+const ALL_CONFIGS = paruConfigs as unknown as Record<string, StageConfig>;
+
+// ============================================================================
+// Gate helpers (extracted from GridViewer)
+// ============================================================================
+
+const DIRECTION_ORDER: Direction[] = ['north', 'east', 'south', 'west'];
+
+/** Get original gate directions for a stage (before rotation) */
+export function getOriginalGates(stageName: string): Set<Direction> {
+  const config = ALL_CONFIGS[stageName];
+  if (!config) return new Set();
+  return new Set(config.gates.map(g => g.edge as Direction));
+}
+
+/** Rotate a direction CW by degrees (0, 90, 180, 270) */
+export function rotateDirection(dir: Direction, rotation: number): Direction {
+  if (rotation === 0) return dir;
+  const idx = DIRECTION_ORDER.indexOf(dir);
+  if (idx < 0) return dir;
+  const steps = ((rotation / 90) % 4 + 4) % 4;
+  return DIRECTION_ORDER[(idx + steps) % 4];
+}
+
+/** Get gate directions after applying rotation (grid-space gates) */
+export function getRotatedGates(stageName: string, rotation: number): Set<Direction> {
+  const original = getOriginalGates(stageName);
+  if (rotation === 0) return original;
+  return new Set([...original].map(g => rotateDirection(g, rotation)));
+}
+
+/** Get opposite direction */
+export function oppositeDirection(dir: Direction): Direction {
+  const opposites: Record<Direction, Direction> = {
+    north: 'south',
+    south: 'north',
+    east: 'west',
+    west: 'east',
+  };
+  return opposites[dir];
+}
+
+/** Get neighbor position in a direction */
+export function getNeighbor(row: number, col: number, dir: Direction): [number, number] {
+  switch (dir) {
+    case 'north': return [row - 1, col];
+    case 'south': return [row + 1, col];
+    case 'east': return [row, col + 1];
+    case 'west': return [row, col - 1];
+  }
+}
+
+/** Check if position is valid in grid */
+export function isValidPos(row: number, col: number, gridSize: number): boolean {
+  return row >= 0 && row < gridSize && col >= 0 && col < gridSize;
+}
+
+/** Get the StageConfig for a stage name */
+export function getStageConfig(stageName: string): StageConfig | undefined {
+  return ALL_CONFIGS[stageName];
+}
+
+// ============================================================================
+// Stage filtering
+// ============================================================================
+
+/** Get all stage names for an area and variant */
+export function getStagesForArea(areaKey: string, variant: string): string[] {
+  const area = EDITOR_AREAS.find(a => a.key === areaKey);
+  if (!area) return [];
+  const prefix = `${area.prefix}${variant}_`;
+  return Object.keys(ALL_CONFIGS).filter(k => k.startsWith(prefix));
+}
+
+/** Get stage suffix (e.g., "ib1" from "s01a_ib1") */
+export function getStageSuffix(stageName: string): string {
+  const idx = stageName.indexOf('_');
+  return idx >= 0 ? stageName.substring(idx + 1) : stageName;
+}
+
+// ============================================================================
+// Hook
+// ============================================================================
+
+export interface UseStageConfigsReturn {
+  /** All available configs */
+  allConfigs: Record<string, StageConfig>;
+  /** Get stages filtered for current area/variant */
+  getStages: (areaKey: string, variant: string) => string[];
+  /** Get config for a specific stage */
+  getConfig: (stageName: string) => StageConfig | undefined;
+}
+
+export function useStageConfigs(): UseStageConfigsReturn {
+  const getStages = useMemo(() => {
+    // Cache results by area+variant
+    const cache = new Map<string, string[]>();
+    return (areaKey: string, variant: string): string[] => {
+      const key = `${areaKey}:${variant}`;
+      if (!cache.has(key)) {
+        cache.set(key, getStagesForArea(areaKey, variant));
+      }
+      return cache.get(key)!;
+    };
+  }, []);
+
+  return {
+    allConfigs: ALL_CONFIGS,
+    getStages,
+    getConfig: getStageConfig,
+  };
+}

--- a/src/components/quest-editor/shared/CellInspector.tsx
+++ b/src/components/quest-editor/shared/CellInspector.tsx
@@ -1,0 +1,307 @@
+/**
+ * CellInspector — Right panel for editing a selected cell
+ *
+ * Shows stage info, gate visualization, role dropdown,
+ * start/end toggle, key/key-gate controls, notes.
+ */
+
+import type { QuestProject, EditorGridCell, CellRole, Direction } from '../types';
+import { ROLE_COLORS, ROLE_LABELS } from '../types';
+import { getRotatedGates, getStageSuffix } from '../hooks/useStageConfigs';
+
+interface CellInspectorProps {
+  project: QuestProject;
+  selectedCell: string;
+  onUpdateCell: (pos: string, updates: Partial<EditorGridCell>) => void;
+  onSetStart: (pos: string) => void;
+  onSetEnd: (pos: string) => void;
+  onToggleKey: (pos: string) => void;
+  onToggleKeyGate: (pos: string) => void;
+  onClearCell: (pos: string) => void;
+  onChangeStage: (pos: string) => void;
+}
+
+const ALL_ROLES: CellRole[] = ['transit', 'guard', 'puzzle', 'cache', 'landmark', 'boss'];
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#888',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.5px',
+  marginBottom: '4px',
+};
+
+const sectionStyle: React.CSSProperties = {
+  marginBottom: '16px',
+};
+
+export default function CellInspector({
+  project,
+  selectedCell,
+  onUpdateCell,
+  onSetStart,
+  onSetEnd,
+  onToggleKey,
+  onToggleKeyGate,
+  onClearCell,
+  onChangeStage,
+}: CellInspectorProps) {
+  const cell = project.cells[selectedCell];
+  if (!cell) {
+    return (
+      <div style={{ padding: '1rem', color: '#888' }}>
+        <div style={labelStyle}>Empty Cell</div>
+        <p style={{ fontSize: '13px' }}>Click an empty cell to place a stage, or select an occupied cell to edit it.</p>
+        <p style={{ fontSize: '12px', color: '#666', marginTop: '8px' }}>
+          Position: {selectedCell}
+        </p>
+      </div>
+    );
+  }
+
+  const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+  const suffix = getStageSuffix(cell.stageName);
+  const isStart = project.startPos === selectedCell;
+  const isEnd = project.endPos === selectedCell;
+  const hasKey = Object.values(project.keyLinks).includes(selectedCell);
+  const isKeyGate = selectedCell in project.keyLinks;
+
+  return (
+    <div style={{ padding: '1rem', overflowY: 'auto', maxHeight: 'calc(100vh - 200px)' }}>
+      {/* Header */}
+      <div style={sectionStyle}>
+        <div style={{ fontSize: '18px', fontWeight: 700, color: '#fff', marginBottom: '4px' }}>
+          {suffix}
+        </div>
+        <div style={{ fontSize: '12px', color: '#888' }}>
+          {cell.stageName} at {selectedCell}
+        </div>
+        {cell.manual && (
+          <div style={{ fontSize: '10px', color: '#88aaff', marginTop: '4px' }}>
+            Manually placed
+          </div>
+        )}
+        {(cell.rotation ?? 0) !== 0 && (
+          <div style={{ fontSize: '10px', color: '#ffcc66', marginTop: '4px' }}>
+            Rotated {cell.rotation}&deg;
+          </div>
+        )}
+      </div>
+
+      {/* Gates visualization */}
+      <div style={sectionStyle}>
+        <div style={labelStyle}>Gates</div>
+        <div style={{
+          display: 'grid',
+          gridTemplateColumns: '1fr 1fr 1fr',
+          gridTemplateRows: '1fr 1fr 1fr',
+          width: '100px',
+          height: '100px',
+          gap: '2px',
+          margin: '0 auto',
+        }}>
+          <div />
+          <div style={{
+            background: gates.has('north') ? '#88ff88' : '#333',
+            borderRadius: '2px',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: '8px', color: '#fff',
+          }}>N</div>
+          <div />
+          <div style={{
+            background: gates.has('west') ? '#88ff88' : '#333',
+            borderRadius: '2px',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: '8px', color: '#fff',
+          }}>W</div>
+          <div style={{
+            background: ROLE_COLORS[cell.role],
+            borderRadius: '2px',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: '9px', color: '#fff', fontWeight: 600,
+          }}>{suffix}</div>
+          <div style={{
+            background: gates.has('east') ? '#88ff88' : '#333',
+            borderRadius: '2px',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: '8px', color: '#fff',
+          }}>E</div>
+          <div />
+          <div style={{
+            background: gates.has('south') ? '#88ff88' : '#333',
+            borderRadius: '2px',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: '8px', color: '#fff',
+          }}>S</div>
+          <div />
+        </div>
+      </div>
+
+      {/* Role */}
+      <div style={sectionStyle}>
+        <div style={labelStyle}>Role</div>
+        <select
+          value={cell.role}
+          onChange={(e) => onUpdateCell(selectedCell, { role: e.target.value as CellRole })}
+          style={{
+            width: '100%',
+            padding: '8px',
+            background: '#2a2a4a',
+            border: `1px solid ${ROLE_COLORS[cell.role]}`,
+            borderRadius: '4px',
+            color: '#fff',
+            fontSize: '13px',
+          }}
+        >
+          {ALL_ROLES.map(role => (
+            <option key={role} value={role}>{ROLE_LABELS[role]}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Start / End */}
+      <div style={sectionStyle}>
+        <div style={labelStyle}>Markers</div>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            onClick={() => onSetStart(selectedCell)}
+            style={{
+              flex: 1,
+              padding: '8px',
+              background: isStart ? '#66aaff' : '#2a2a4a',
+              border: `1px solid ${isStart ? '#88ccff' : '#444'}`,
+              borderRadius: '4px',
+              color: '#fff',
+              fontSize: '12px',
+              fontWeight: isStart ? 700 : 400,
+              cursor: 'pointer',
+            }}
+          >
+            {isStart ? 'Start' : 'Set Start'}
+          </button>
+          <button
+            onClick={() => onSetEnd(selectedCell)}
+            style={{
+              flex: 1,
+              padding: '8px',
+              background: isEnd ? '#ffaa66' : '#2a2a4a',
+              border: `1px solid ${isEnd ? '#ffcc88' : '#444'}`,
+              borderRadius: '4px',
+              color: '#fff',
+              fontSize: '12px',
+              fontWeight: isEnd ? 700 : 400,
+              cursor: 'pointer',
+            }}
+          >
+            {isEnd ? 'End' : 'Set End'}
+          </button>
+        </div>
+      </div>
+
+      {/* Key & Key-Gate */}
+      <div style={sectionStyle}>
+        <div style={labelStyle}>Keys</div>
+        <div style={{ display: 'flex', gap: '8px' }}>
+          <button
+            onClick={() => onToggleKey(selectedCell)}
+            style={{
+              flex: 1,
+              padding: '8px',
+              background: hasKey ? '#ff66aa' : '#2a2a4a',
+              border: `1px solid ${hasKey ? '#ff88cc' : '#444'}`,
+              borderRadius: '4px',
+              color: '#fff',
+              fontSize: '12px',
+              fontWeight: hasKey ? 700 : 400,
+              cursor: 'pointer',
+            }}
+          >
+            {hasKey ? 'Has Key' : 'Add Key'}
+          </button>
+          <button
+            onClick={() => onToggleKeyGate(selectedCell)}
+            style={{
+              flex: 1,
+              padding: '8px',
+              background: isKeyGate ? '#ff66ff' : '#2a2a4a',
+              border: `1px solid ${isKeyGate ? '#ff88ff' : '#444'}`,
+              borderRadius: '4px',
+              color: '#fff',
+              fontSize: '12px',
+              fontWeight: isKeyGate ? 700 : 400,
+              cursor: 'pointer',
+            }}
+          >
+            {isKeyGate ? 'Key-Gate' : 'Add Gate'}
+          </button>
+        </div>
+        {isKeyGate && (
+          <div style={{ fontSize: '11px', color: '#cc88ff', marginTop: '4px' }}>
+            Key at: {project.keyLinks[selectedCell] || 'unlinked'}
+          </div>
+        )}
+        {hasKey && (
+          <div style={{ fontSize: '11px', color: '#ff88aa', marginTop: '4px' }}>
+            Unlocks: {Object.entries(project.keyLinks).find(([_, v]) => v === selectedCell)?.[0] || 'unlinked'}
+          </div>
+        )}
+      </div>
+
+      {/* Notes */}
+      <div style={sectionStyle}>
+        <div style={labelStyle}>Notes</div>
+        <textarea
+          value={cell.notes || ''}
+          onChange={(e) => onUpdateCell(selectedCell, { notes: e.target.value || undefined })}
+          placeholder="Optional designer notes..."
+          rows={3}
+          style={{
+            width: '100%',
+            padding: '8px',
+            background: '#2a2a4a',
+            border: '1px solid #444',
+            borderRadius: '4px',
+            color: '#fff',
+            fontSize: '12px',
+            resize: 'vertical',
+            fontFamily: 'inherit',
+          }}
+        />
+      </div>
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: '8px' }}>
+        <button
+          onClick={() => onChangeStage(selectedCell)}
+          style={{
+            flex: 1,
+            padding: '8px',
+            background: '#555588',
+            border: 'none',
+            borderRadius: '4px',
+            color: '#fff',
+            fontSize: '12px',
+            cursor: 'pointer',
+          }}
+        >
+          Change Stage
+        </button>
+        <button
+          onClick={() => onClearCell(selectedCell)}
+          style={{
+            flex: 1,
+            padding: '8px',
+            background: '#884444',
+            border: 'none',
+            borderRadius: '4px',
+            color: '#fff',
+            fontSize: '12px',
+            cursor: 'pointer',
+          }}
+        >
+          Clear Cell
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/quest-editor/shared/CellInspector.tsx
+++ b/src/components/quest-editor/shared/CellInspector.tsx
@@ -17,6 +17,7 @@ interface CellInspectorProps {
   onSetEnd: (pos: string) => void;
   onToggleKey: (pos: string) => void;
   onToggleKeyGate: (pos: string) => void;
+  onSetLockedGate: (pos: string, dir: Direction | undefined) => void;
   onClearCell: (pos: string) => void;
   onChangeStage: (pos: string) => void;
 }
@@ -43,6 +44,7 @@ export default function CellInspector({
   onSetEnd,
   onToggleKey,
   onToggleKeyGate,
+  onSetLockedGate,
   onClearCell,
   onChangeStage,
 }: CellInspectorProps) {
@@ -88,9 +90,9 @@ export default function CellInspector({
         )}
       </div>
 
-      {/* Gates visualization */}
+      {/* Gates visualization — click a gate to toggle key-lock */}
       <div style={sectionStyle}>
-        <div style={labelStyle}>Gates</div>
+        <div style={labelStyle}>Gates {isKeyGate && '(click gate to lock)'}</div>
         <div style={{
           display: 'grid',
           gridTemplateColumns: '1fr 1fr 1fr',
@@ -100,40 +102,35 @@ export default function CellInspector({
           gap: '2px',
           margin: '0 auto',
         }}>
-          <div />
+          {(['north', 'west', 'east', 'south'] as Direction[]).map(dir => {
+            const hasGate = gates.has(dir);
+            const isLocked = cell.lockedGate === dir;
+            const bg = isLocked ? '#ff66ff' : hasGate ? '#88ff88' : '#333';
+            const clickable = isKeyGate && hasGate;
+            const gridArea = dir === 'north' ? '1/2' : dir === 'west' ? '2/1' : dir === 'east' ? '2/3' : '3/2';
+            return (
+              <div
+                key={dir}
+                onClick={clickable ? () => onSetLockedGate(selectedCell, isLocked ? undefined : dir) : undefined}
+                style={{
+                  gridArea,
+                  background: bg,
+                  borderRadius: '2px',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: '8px', color: '#fff',
+                  cursor: clickable ? 'pointer' : 'default',
+                  border: isLocked ? '2px solid #ff88ff' : '2px solid transparent',
+                }}
+              >{dir[0].toUpperCase()}</div>
+            );
+          })}
           <div style={{
-            background: gates.has('north') ? '#88ff88' : '#333',
-            borderRadius: '2px',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: '8px', color: '#fff',
-          }}>N</div>
-          <div />
-          <div style={{
-            background: gates.has('west') ? '#88ff88' : '#333',
-            borderRadius: '2px',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: '8px', color: '#fff',
-          }}>W</div>
-          <div style={{
+            gridArea: '2/2',
             background: ROLE_COLORS[cell.role],
             borderRadius: '2px',
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             fontSize: '9px', color: '#fff', fontWeight: 600,
           }}>{suffix}</div>
-          <div style={{
-            background: gates.has('east') ? '#88ff88' : '#333',
-            borderRadius: '2px',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: '8px', color: '#fff',
-          }}>E</div>
-          <div />
-          <div style={{
-            background: gates.has('south') ? '#88ff88' : '#333',
-            borderRadius: '2px',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            fontSize: '8px', color: '#fff',
-          }}>S</div>
-          <div />
         </div>
       </div>
 
@@ -236,9 +233,14 @@ export default function CellInspector({
           </button>
         </div>
         {isKeyGate && (
-          <div style={{ fontSize: '11px', color: '#cc88ff', marginTop: '4px' }}>
-            Key at: {project.keyLinks[selectedCell] || 'unlinked'}
-          </div>
+          <>
+            <div style={{ fontSize: '11px', color: '#cc88ff', marginTop: '4px' }}>
+              Locked: {cell.lockedGate ? `${cell.lockedGate} gate` : 'click a gate above to lock'}
+            </div>
+            <div style={{ fontSize: '11px', color: '#cc88ff', marginTop: '2px' }}>
+              Key at: {project.keyLinks[selectedCell] || 'unlinked'}
+            </div>
+          </>
         )}
         {hasKey && (
           <div style={{ fontSize: '11px', color: '#ff88aa', marginTop: '4px' }}>

--- a/src/components/quest-editor/shared/GridCanvas.tsx
+++ b/src/components/quest-editor/shared/GridCanvas.tsx
@@ -5,6 +5,7 @@
  * Click occupied cell → onCellSelect (for CellInspector)
  */
 
+import { useMemo } from 'react';
 import type { QuestProject, EditorGridCell, Direction } from '../types';
 import { ROLE_COLORS } from '../types';
 import { getRotatedGates, oppositeDirection, getNeighbor, isValidPos } from '../hooks/useStageConfigs';
@@ -54,17 +55,57 @@ function getGateColor(
   return '#88ff88'; // Normal connected gate
 }
 
+/** BFS from startPos to determine entry direction for each cell */
+function computeEntryDirections(project: QuestProject): Map<string, Direction> {
+  const entries = new Map<string, Direction>();
+  if (!project.startPos || !project.cells[project.startPos]) return entries;
+
+  const visited = new Set<string>();
+  const queue: string[] = [project.startPos];
+  visited.add(project.startPos);
+
+  while (queue.length > 0) {
+    const pos = queue.shift()!;
+    const cell = project.cells[pos];
+    if (!cell) continue;
+
+    const [row, col] = pos.split(',').map(Number);
+    const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+
+    for (const dir of gates) {
+      const [nr, nc] = getNeighbor(row, col, dir);
+      const nk = `${nr},${nc}`;
+      if (visited.has(nk)) continue;
+      if (!isValidPos(nr, nc, project.gridSize)) continue;
+
+      const neighbor = project.cells[nk];
+      if (!neighbor) continue;
+
+      const neighborGates = getRotatedGates(neighbor.stageName, neighbor.rotation ?? 0);
+      if (!neighborGates.has(oppositeDirection(dir))) continue;
+
+      visited.add(nk);
+      entries.set(nk, oppositeDirection(dir));
+      queue.push(nk);
+    }
+  }
+
+  return entries;
+}
+
 function CellDisplay({
   pos,
   cell,
   project,
   isSelected,
+  entryDir,
   onClick,
 }: {
   pos: string;
   cell: EditorGridCell | null;
   project: QuestProject;
   isSelected: boolean;
+  entryDir: Direction | null;
   onClick: () => void;
 }) {
   const [row, col] = pos.split(',').map(Number);
@@ -172,33 +213,37 @@ function CellDisplay({
         {cell.role}
       </div>
 
-      {/* Gate bars: N/S/E/W */}
+      {/* Gate bars: N/S/E/W — entry gate shown at 50% opacity */}
       {gates.has('north') && (
         <div style={{
           position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)',
           width: '22px', height: '5px', borderRadius: '0 0 3px 3px',
-          background: getGateColor(project, pos, cell, 'north', project.gridSize),
+          background: entryDir === 'north' ? '#88ff88' : getGateColor(project, pos, cell, 'north', project.gridSize),
+          opacity: entryDir === 'north' ? 0.5 : 1,
         }} />
       )}
       {gates.has('south') && (
         <div style={{
           position: 'absolute', bottom: 0, left: '50%', transform: 'translateX(-50%)',
           width: '22px', height: '5px', borderRadius: '3px 3px 0 0',
-          background: getGateColor(project, pos, cell, 'south', project.gridSize),
+          background: entryDir === 'south' ? '#88ff88' : getGateColor(project, pos, cell, 'south', project.gridSize),
+          opacity: entryDir === 'south' ? 0.5 : 1,
         }} />
       )}
       {gates.has('east') && (
         <div style={{
           position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)',
           width: '5px', height: '22px', borderRadius: '3px 0 0 3px',
-          background: getGateColor(project, pos, cell, 'east', project.gridSize),
+          background: entryDir === 'east' ? '#88ff88' : getGateColor(project, pos, cell, 'east', project.gridSize),
+          opacity: entryDir === 'east' ? 0.5 : 1,
         }} />
       )}
       {gates.has('west') && (
         <div style={{
           position: 'absolute', left: 0, top: '50%', transform: 'translateY(-50%)',
           width: '5px', height: '22px', borderRadius: '0 3px 3px 0',
-          background: getGateColor(project, pos, cell, 'west', project.gridSize),
+          background: entryDir === 'west' ? '#88ff88' : getGateColor(project, pos, cell, 'west', project.gridSize),
+          opacity: entryDir === 'west' ? 0.5 : 1,
         }} />
       )}
 
@@ -212,6 +257,7 @@ function CellDisplay({
 
 export default function GridCanvas({ project, selectedCell, onCellClick, onCellSelect }: GridCanvasProps) {
   const { gridSize, cells } = project;
+  const entryDirs = useMemo(() => computeEntryDirections(project), [project]);
 
   return (
     <div style={{
@@ -236,6 +282,7 @@ export default function GridCanvas({ project, selectedCell, onCellClick, onCellS
                 cell={cell}
                 project={project}
                 isSelected={isSelected}
+                entryDir={entryDirs.get(pos) ?? null}
                 onClick={() => cell ? onCellSelect(pos) : onCellClick(pos)}
               />
             );

--- a/src/components/quest-editor/shared/GridCanvas.tsx
+++ b/src/components/quest-editor/shared/GridCanvas.tsx
@@ -33,11 +33,9 @@ function getGateColor(
   const [row, col] = pos.split(',').map(Number);
   const [nr, nc] = getNeighbor(row, col, direction);
 
-  // Key-gate?
+  // Key-locked gate? Only color the specific locked direction
   const isKeyGate = Object.keys(project.keyLinks).includes(pos);
-  if (isKeyGate) {
-    // Check if this specific direction has the key-gate
-    // For simplicity, color all gates on key-gate cells
+  if (isKeyGate && cell.lockedGate === direction) {
     return '#ff66ff';
   }
 

--- a/src/components/quest-editor/shared/GridCanvas.tsx
+++ b/src/components/quest-editor/shared/GridCanvas.tsx
@@ -1,0 +1,249 @@
+/**
+ * GridCanvas — Renders the NxN grid with cells, gates, badges
+ *
+ * Click empty cell → onCellClick (for StagePicker)
+ * Click occupied cell → onCellSelect (for CellInspector)
+ */
+
+import type { QuestProject, EditorGridCell, Direction } from '../types';
+import { ROLE_COLORS } from '../types';
+import { getRotatedGates, oppositeDirection, getNeighbor, isValidPos } from '../hooks/useStageConfigs';
+
+interface GridCanvasProps {
+  project: QuestProject;
+  selectedCell: string | null;
+  onCellClick: (pos: string) => void;
+  onCellSelect: (pos: string) => void;
+}
+
+/** Get suffix from stage name (e.g., "s01a_ib1" → "ib1") */
+function getSuffix(stageName: string): string {
+  const idx = stageName.indexOf('_');
+  return idx >= 0 ? stageName.substring(idx + 1) : stageName;
+}
+
+/** Get gate display color based on cell state */
+function getGateColor(
+  project: QuestProject,
+  pos: string,
+  cell: EditorGridCell,
+  direction: Direction,
+  gridSize: number,
+): string {
+  const [row, col] = pos.split(',').map(Number);
+  const [nr, nc] = getNeighbor(row, col, direction);
+
+  // Key-gate?
+  const isKeyGate = Object.keys(project.keyLinks).includes(pos);
+  if (isKeyGate) {
+    // Check if this specific direction has the key-gate
+    // For simplicity, color all gates on key-gate cells
+    return '#ff66ff';
+  }
+
+  // Warp exit (gate points outside grid)
+  if (!isValidPos(nr, nc, gridSize)) return '#aa66ff';
+
+  // Gate to empty neighbor
+  const neighborKey = `${nr},${nc}`;
+  if (!project.cells[neighborKey]) return '#ccaa44';
+
+  // Gate to occupied neighbor — check if neighbor has matching gate
+  const neighbor = project.cells[neighborKey];
+  const neighborGates = getRotatedGates(neighbor.stageName, neighbor.rotation ?? 0);
+  if (!neighborGates.has(oppositeDirection(direction))) return '#cc4444'; // Orphan — red
+
+  return '#88ff88'; // Normal connected gate
+}
+
+function CellDisplay({
+  pos,
+  cell,
+  project,
+  isSelected,
+  onClick,
+}: {
+  pos: string;
+  cell: EditorGridCell | null;
+  project: QuestProject;
+  isSelected: boolean;
+  onClick: () => void;
+}) {
+  const [row, col] = pos.split(',').map(Number);
+
+  if (!cell) {
+    // Empty cell
+    return (
+      <div
+        onClick={onClick}
+        style={{
+          width: '110px',
+          height: '110px',
+          background: isSelected ? '#2a2a4a' : '#1a1a2e',
+          border: `1px solid ${isSelected ? '#5588ff' : '#333'}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          color: '#444',
+          fontSize: '10px',
+          cursor: 'pointer',
+          transition: 'background 0.1s',
+        }}
+        onMouseEnter={(e) => { if (!isSelected) e.currentTarget.style.background = '#222244'; }}
+        onMouseLeave={(e) => { if (!isSelected) e.currentTarget.style.background = '#1a1a2e'; }}
+      >
+        {row},{col}
+      </div>
+    );
+  }
+
+  const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+  const roleColor = ROLE_COLORS[cell.role];
+  const isStart = project.startPos === pos;
+  const isEnd = project.endPos === pos;
+  const hasKey = Object.values(project.keyLinks).includes(pos);
+  const isKeyGate = pos in project.keyLinks;
+
+  return (
+    <div
+      onClick={onClick}
+      style={{
+        width: '110px',
+        height: '110px',
+        background: isSelected ? '#3a3a6a' : '#2a2a4a',
+        border: `2px solid ${isSelected ? '#88aaff' : roleColor}`,
+        position: 'relative',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        cursor: 'pointer',
+        transition: 'all 0.1s',
+      }}
+      onMouseEnter={(e) => { if (!isSelected) e.currentTarget.style.background = '#333366'; }}
+      onMouseLeave={(e) => { if (!isSelected) e.currentTarget.style.background = '#2a2a4a'; }}
+    >
+      {/* Start badge */}
+      {isStart && (
+        <div style={{
+          position: 'absolute', top: '3px', left: '3px',
+          background: '#66aaff', color: '#fff', fontSize: '7px',
+          padding: '1px 4px', borderRadius: '3px', fontWeight: 700,
+        }}>START</div>
+      )}
+
+      {/* End badge */}
+      {isEnd && (
+        <div style={{
+          position: 'absolute', top: '3px', left: '3px',
+          background: '#ffaa66', color: '#fff', fontSize: '7px',
+          padding: '1px 4px', borderRadius: '3px', fontWeight: 700,
+        }}>END</div>
+      )}
+
+      {/* Key badge */}
+      {hasKey && (
+        <div style={{
+          position: 'absolute', top: '3px', right: '3px',
+          width: '14px', height: '14px', background: '#ff66aa',
+          borderRadius: '50%', border: '2px solid #fff',
+        }} title="Key" />
+      )}
+
+      {/* Key-gate badge */}
+      {isKeyGate && (
+        <div style={{
+          position: 'absolute', top: '3px', right: hasKey ? '22px' : '3px',
+          width: '14px', height: '14px', background: '#ff66ff',
+          borderRadius: '2px', border: '2px solid #fff',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: '8px', color: '#fff', fontWeight: 700,
+        }} title="Key-Gate">G</div>
+      )}
+
+      {/* Stage suffix */}
+      <div style={{ color: '#fff', fontSize: '11px', fontWeight: 600, textAlign: 'center' }}>
+        {getSuffix(cell.stageName)}
+      </div>
+
+      {/* Role label */}
+      <div style={{
+        color: roleColor, fontSize: '8px', marginTop: '2px',
+        textTransform: 'uppercase', fontWeight: 600,
+      }}>
+        {cell.role}
+      </div>
+
+      {/* Gate bars: N/S/E/W */}
+      {gates.has('north') && (
+        <div style={{
+          position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)',
+          width: '22px', height: '5px', borderRadius: '0 0 3px 3px',
+          background: getGateColor(project, pos, cell, 'north', project.gridSize),
+        }} />
+      )}
+      {gates.has('south') && (
+        <div style={{
+          position: 'absolute', bottom: 0, left: '50%', transform: 'translateX(-50%)',
+          width: '22px', height: '5px', borderRadius: '3px 3px 0 0',
+          background: getGateColor(project, pos, cell, 'south', project.gridSize),
+        }} />
+      )}
+      {gates.has('east') && (
+        <div style={{
+          position: 'absolute', right: 0, top: '50%', transform: 'translateY(-50%)',
+          width: '5px', height: '22px', borderRadius: '3px 0 0 3px',
+          background: getGateColor(project, pos, cell, 'east', project.gridSize),
+        }} />
+      )}
+      {gates.has('west') && (
+        <div style={{
+          position: 'absolute', left: 0, top: '50%', transform: 'translateY(-50%)',
+          width: '5px', height: '22px', borderRadius: '0 3px 3px 0',
+          background: getGateColor(project, pos, cell, 'west', project.gridSize),
+        }} />
+      )}
+
+      {/* Coordinate */}
+      <div style={{ position: 'absolute', bottom: '2px', right: '4px', fontSize: '8px', color: '#555' }}>
+        {row},{col}
+      </div>
+    </div>
+  );
+}
+
+export default function GridCanvas({ project, selectedCell, onCellClick, onCellSelect }: GridCanvasProps) {
+  const { gridSize, cells } = project;
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '2px',
+      background: '#111',
+      padding: '4px',
+      borderRadius: '8px',
+    }}>
+      {Array.from({ length: gridSize }, (_, row) => (
+        <div key={row} style={{ display: 'flex', gap: '2px' }}>
+          {Array.from({ length: gridSize }, (_, col) => {
+            const pos = `${row},${col}`;
+            const cell = cells[pos] || null;
+            const isSelected = selectedCell === pos;
+
+            return (
+              <CellDisplay
+                key={col}
+                pos={pos}
+                cell={cell}
+                project={project}
+                isSelected={isSelected}
+                onClick={() => cell ? onCellSelect(pos) : onCellClick(pos)}
+              />
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/quest-editor/shared/StagePicker.tsx
+++ b/src/components/quest-editor/shared/StagePicker.tsx
@@ -1,0 +1,357 @@
+/**
+ * StagePicker — Modal for selecting a stage to place in a cell
+ *
+ * Filters stages by gate compatibility with neighbors.
+ */
+
+import { useState, useMemo } from 'react';
+import type { QuestProject, Direction } from '../types';
+import {
+  getOriginalGates,
+  getRotatedGates,
+  rotateDirection,
+  getNeighbor,
+  isValidPos,
+  oppositeDirection,
+  getStagesForArea,
+  getStageSuffix,
+} from '../hooks/useStageConfigs';
+
+interface StagePickerProps {
+  project: QuestProject;
+  targetPos: string;
+  onSelect: (stageName: string, rotation: number) => void;
+  onClose: () => void;
+}
+
+interface StageCandidate {
+  stageName: string;
+  rotation: number;
+}
+
+/** Mini 3x3 grid icon showing gate positions */
+function GateIcon({ gates, size = 28 }: { gates: Set<Direction>; size?: number }) {
+  const cellSize = size / 3;
+  const active = '#88ff88';
+  const inactive = '#222';
+  const center = '#555';
+
+  const dirs: { dir: Direction; row: number; col: number }[] = [
+    { dir: 'north', row: 0, col: 1 },
+    { dir: 'west', row: 1, col: 0 },
+    { dir: 'east', row: 1, col: 2 },
+    { dir: 'south', row: 2, col: 1 },
+  ];
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>
+      {/* Background */}
+      <rect width={size} height={size} fill="#111" rx={2} />
+      {/* Center dot */}
+      <rect
+        x={cellSize} y={cellSize}
+        width={cellSize} height={cellSize}
+        fill={center} rx={1}
+      />
+      {/* Gate cells */}
+      {dirs.map(({ dir, row, col }) => (
+        <rect
+          key={dir}
+          x={col * cellSize + 0.5}
+          y={row * cellSize + 0.5}
+          width={cellSize - 1}
+          height={cellSize - 1}
+          fill={gates.has(dir) ? active : inactive}
+          rx={1}
+        />
+      ))}
+    </svg>
+  );
+}
+
+/**
+ * Determine gate constraints for a cell position based on neighbors.
+ * Returns required gates (must connect to occupied neighbor) and
+ * forbidden gates (must not connect to empty neighbor or outside grid).
+ */
+function getConstraints(
+  project: QuestProject,
+  pos: string,
+): { required: Direction[]; forbidden: Direction[] } {
+  const [row, col] = pos.split(',').map(Number);
+  const directions: Direction[] = ['north', 'south', 'east', 'west'];
+  const required: Direction[] = [];
+  const forbidden: Direction[] = [];
+
+  for (const dir of directions) {
+    const [nr, nc] = getNeighbor(row, col, dir);
+
+    if (!isValidPos(nr, nc, project.gridSize)) {
+      // Outside grid — gate here would be a warp. Not forbidden, but not required.
+      continue;
+    }
+
+    const neighborKey = `${nr},${nc}`;
+    const neighbor = project.cells[neighborKey];
+
+    if (neighbor) {
+      // Occupied neighbor — check if it has a gate pointing back at us
+      const neighborGates = getRotatedGates(neighbor.stageName, neighbor.rotation ?? 0);
+      if (neighborGates.has(oppositeDirection(dir))) {
+        // Neighbor has a gate toward us — we MUST have a gate this direction
+        required.push(dir);
+      } else {
+        // Neighbor exists but no gate toward us — we must NOT have a gate this direction
+        forbidden.push(dir);
+      }
+    }
+    // Empty neighbor — no constraint (gate okay or not)
+  }
+
+  return { required, forbidden };
+}
+
+export default function StagePicker({ project, targetPos, onSelect, onClose }: StagePickerProps) {
+  const [search, setSearch] = useState('');
+  const [showAll, setShowAll] = useState(false);
+
+  const stages = useMemo(
+    () => getStagesForArea(project.areaKey, project.variant),
+    [project.areaKey, project.variant]
+  );
+
+  const constraints = useMemo(
+    () => getConstraints(project, targetPos),
+    [project, targetPos]
+  );
+
+  const candidates = useMemo(() => {
+    const result: StageCandidate[] = [];
+
+    for (const stageName of stages) {
+      const originalGates = getOriginalGates(stageName);
+      const isSingleGate = originalGates.size === 1;
+
+      // Single-gate stages: try all 4 rotations
+      // Multi-gate stages: rotation=0 only
+      const rotations = isSingleGate ? [0, 90, 180, 270] : [0];
+
+      for (const rot of rotations) {
+        const gates = isSingleGate ? getRotatedGates(stageName, rot) : originalGates;
+
+        // Check required: must have gates in these directions
+        let meetsRequired = true;
+        for (const dir of constraints.required) {
+          if (!gates.has(dir)) {
+            meetsRequired = false;
+            break;
+          }
+        }
+        if (!meetsRequired) continue;
+
+        // Check forbidden: must NOT have gates in these directions
+        let hasForbidden = false;
+        for (const dir of constraints.forbidden) {
+          if (gates.has(dir)) {
+            hasForbidden = true;
+            break;
+          }
+        }
+        if (hasForbidden) continue;
+
+        result.push({ stageName, rotation: rot });
+      }
+    }
+
+    return result;
+  }, [stages, constraints]);
+
+  // Filter by search
+  const filtered = useMemo(() => {
+    if (!search) return showAll ? candidates : candidates.slice(0, 30);
+    const q = search.toLowerCase();
+    const matches = candidates.filter(c =>
+      c.stageName.toLowerCase().includes(q) ||
+      getStageSuffix(c.stageName).toLowerCase().includes(q)
+    );
+    return showAll ? matches : matches.slice(0, 30);
+  }, [candidates, search, showAll]);
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, zIndex: 1000,
+        background: 'rgba(0,0,0,0.7)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: '#1a1a2e',
+          border: '1px solid #444',
+          borderRadius: '12px',
+          width: '600px',
+          maxHeight: '80vh',
+          display: 'flex',
+          flexDirection: 'column',
+          overflow: 'hidden',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div style={{
+          padding: '16px',
+          borderBottom: '1px solid #333',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '8px',
+        }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <div style={{ fontSize: '16px', fontWeight: 700, color: '#fff' }}>
+              Select Stage
+            </div>
+            <button
+              onClick={onClose}
+              style={{
+                background: 'none', border: 'none', color: '#888',
+                fontSize: '18px', cursor: 'pointer', padding: '4px',
+              }}
+            >
+              ✕
+            </button>
+          </div>
+          <div style={{ fontSize: '11px', color: '#888' }}>
+            Position: {targetPos} | Compatible: {candidates.length} of {stages.length} stages
+            {constraints.required.length > 0 && (
+              <span style={{ color: '#88ff88' }}>
+                {' '}| Needs: {constraints.required.map(d => d[0].toUpperCase()).join(',')}
+              </span>
+            )}
+            {constraints.forbidden.length > 0 && (
+              <span style={{ color: '#ff8888' }}>
+                {' '}| No: {constraints.forbidden.map(d => d[0].toUpperCase()).join(',')}
+              </span>
+            )}
+          </div>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search stages..."
+            autoFocus
+            style={{
+              width: '100%',
+              padding: '8px 12px',
+              background: '#2a2a4a',
+              border: '1px solid #444',
+              borderRadius: '6px',
+              color: '#fff',
+              fontSize: '13px',
+            }}
+          />
+        </div>
+
+        {/* Stage list */}
+        <div style={{
+          flex: 1, overflowY: 'auto', padding: '8px',
+          display: 'flex', flexDirection: 'column', gap: '4px',
+        }}>
+          {filtered.length === 0 && (
+            <div style={{ padding: '20px', textAlign: 'center', color: '#888' }}>
+              No compatible stages found
+            </div>
+          )}
+          {filtered.map(candidate => (
+            <StageRow
+              key={`${candidate.stageName}:${candidate.rotation}`}
+              candidate={candidate}
+              onSelect={onSelect}
+            />
+          ))}
+          {!showAll && candidates.length > 30 && (
+            <button
+              onClick={() => setShowAll(true)}
+              style={{
+                padding: '8px',
+                background: '#2a2a4a',
+                border: '1px solid #444',
+                borderRadius: '4px',
+                color: '#88aaff',
+                fontSize: '12px',
+                cursor: 'pointer',
+              }}
+            >
+              Show all {candidates.length} stages...
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function StageRow({
+  candidate,
+  onSelect,
+}: {
+  candidate: StageCandidate;
+  onSelect: (stageName: string, rotation: number) => void;
+}) {
+  const suffix = getStageSuffix(candidate.stageName);
+  const gates = getRotatedGates(candidate.stageName, candidate.rotation);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: '12px',
+        padding: '8px 12px',
+        background: '#222244',
+        borderRadius: '6px',
+        cursor: 'pointer',
+        transition: 'background 0.1s',
+      }}
+      onClick={() => onSelect(candidate.stageName, candidate.rotation)}
+      onMouseEnter={(e) => e.currentTarget.style.background = '#333366'}
+      onMouseLeave={(e) => e.currentTarget.style.background = '#222244'}
+    >
+      {/* Gate icon */}
+      <GateIcon gates={gates} />
+
+      {/* Stage name */}
+      <div style={{ flex: 1 }}>
+        <div style={{ color: '#fff', fontSize: '13px', fontWeight: 600 }}>
+          {suffix}
+          {candidate.rotation !== 0 && (
+            <span style={{ color: '#88aaff', fontSize: '10px', marginLeft: '6px' }}>
+              {candidate.rotation}&deg;
+            </span>
+          )}
+        </div>
+        <div style={{ color: '#666', fontSize: '10px' }}>
+          {candidate.stageName}
+        </div>
+      </div>
+
+      {/* Select button */}
+      <button
+        style={{
+          padding: '4px 10px',
+          background: '#3a3a6a',
+          border: '1px solid #555',
+          borderRadius: '4px',
+          color: '#fff',
+          fontSize: '11px',
+          cursor: 'pointer',
+          transition: 'background 0.1s',
+        }}
+        onMouseEnter={(e) => e.currentTarget.style.background = '#5588ff'}
+        onMouseLeave={(e) => e.currentTarget.style.background = '#3a3a6a'}
+      >
+        Place
+      </button>
+    </div>
+  );
+}

--- a/src/components/quest-editor/shared/grid-generation.ts
+++ b/src/components/quest-editor/shared/grid-generation.ts
@@ -548,6 +548,7 @@ function tryGenerateGrid(
       cells[pos] = {
         stageName: cell.stageName,
         rotation: cell.rotation || undefined,
+        lockedGate: cell.isKeyGate && cell.keyGateDirection ? cell.keyGateDirection as Direction : undefined,
         role,
         manual: false,
       };

--- a/src/components/quest-editor/shared/grid-generation.ts
+++ b/src/components/quest-editor/shared/grid-generation.ts
@@ -1,0 +1,564 @@
+/**
+ * Grid Generation — extracted from GridViewer.tsx
+ *
+ * Parameterized by area configs so it works with any area, not just valley.
+ * Generates random grid layouts with linear paths, branches, and key-gates.
+ */
+
+import type { Direction, EditorGridCell, CellRole } from '../types';
+import {
+  getOriginalGates,
+  getRotatedGates,
+  rotateDirection,
+  getNeighbor,
+  isValidPos,
+  oppositeDirection,
+  getStagesForArea,
+} from '../hooks/useStageConfigs';
+
+// ============================================================================
+// Generation types
+// ============================================================================
+
+export interface GenParams {
+  gridSize: number;
+  usedCells: number;
+  keyGates: number;
+  branches: number;
+}
+
+/** Internal cell used during generation (richer than EditorGridCell) */
+interface GenCell {
+  stageName: string | null;
+  rotation: number;
+  entryDirection: Direction | null;
+  isKeyGate: boolean;
+  keyGateDirection: Direction | null;
+  hasKey: boolean;
+  keyForCell: [number, number] | null;
+  isStart: boolean;
+  isEnd: boolean;
+  isBranch: boolean;
+  pathOrder: number;
+}
+
+export interface GenerationResult {
+  /** Sparse map of EditorGridCells keyed by "row,col" */
+  cells: Record<string, EditorGridCell>;
+  startPos: string | null;
+  endPos: string | null;
+  keyLinks: Record<string, string>;
+  /** Debug info */
+  pathLength: number;
+}
+
+// ============================================================================
+// Core algorithm
+// ============================================================================
+
+function emptyGenCell(): GenCell {
+  return {
+    stageName: null,
+    rotation: 0,
+    entryDirection: null,
+    isKeyGate: false,
+    keyGateDirection: null,
+    hasKey: false,
+    keyForCell: null,
+    isStart: false,
+    isEnd: false,
+    isBranch: false,
+    pathOrder: -1,
+  };
+}
+
+/**
+ * Generate a grid layout for a given area and variant.
+ * Returns sparse EditorGridCell map suitable for QuestProject.
+ */
+export function generateGrid(
+  areaKey: string,
+  variant: string,
+  params: GenParams,
+  maxAttempts = 200
+): GenerationResult {
+  const { gridSize } = params;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    const result = tryGenerateGrid(areaKey, variant, params);
+    if (result) return result;
+  }
+
+  // Fallback: empty
+  return { cells: {}, startPos: null, endPos: null, keyLinks: {}, pathLength: 0 };
+}
+
+function tryGenerateGrid(
+  areaKey: string,
+  variant: string,
+  params: GenParams
+): GenerationResult | null {
+  const { gridSize, usedCells, keyGates, branches } = params;
+
+  // Initialize grid
+  const grid: GenCell[][] = Array(gridSize).fill(null).map(() =>
+    Array(gridSize).fill(null).map(emptyGenCell)
+  );
+
+  const allStages = getStagesForArea(areaKey, variant);
+  if (allStages.length === 0) return null;
+
+  // Find the sa1 stage for this area
+  const area = { key: areaKey, variant };
+  const startStageSuffix = 'sa1';
+  const startStageName = allStages.find(s => s.endsWith(`_${startStageSuffix}`));
+  if (!startStageName) return null;
+
+  const candidateStages = allStages.filter(s => s !== startStageName);
+  const path: [number, number][] = [];
+
+  // Place sa1 at top-center, exiting south
+  const sa1Row = 0;
+  const sa1Col = Math.floor(gridSize / 2);
+
+  // Check sa1's original gates: must have south, other gates must point outside grid
+  const sa1Gates = getOriginalGates(startStageName);
+  if (!sa1Gates.has('south')) return null;
+
+  let sa1Valid = true;
+  for (const gate of sa1Gates) {
+    if (gate === 'south') continue;
+    const [nr, nc] = getNeighbor(sa1Row, sa1Col, gate);
+    if (isValidPos(nr, nc, gridSize)) {
+      sa1Valid = false;
+      break;
+    }
+  }
+  if (!sa1Valid) return null;
+
+  // Place start cell
+  grid[sa1Row][sa1Col] = {
+    stageName: startStageName,
+    rotation: 0,
+    entryDirection: null,
+    isKeyGate: false,
+    keyGateDirection: null,
+    hasKey: false,
+    keyForCell: null,
+    isStart: true,
+    isEnd: false,
+    isBranch: false,
+    pathOrder: 0,
+  };
+  path.push([sa1Row, sa1Col]);
+
+  // Build linear path
+  let currentRow = sa1Row;
+  let currentCol = sa1Col;
+  let lastExitDir: Direction = 'south';
+
+  while (path.length < usedCells) {
+    const [nextRow, nextCol] = getNeighbor(currentRow, currentCol, lastExitDir);
+    const entryDir = oppositeDirection(lastExitDir);
+
+    if (!isValidPos(nextRow, nextCol, gridSize)) break;
+    if (grid[nextRow][nextCol].stageName) break;
+
+    const isLastCell = path.length === usedCells - 1;
+    const validCandidates: { stage: string; exitDir: Direction | null }[] = [];
+
+    for (const stage of candidateStages) {
+      const gates = getOriginalGates(stage);
+      if (!gates.has(entryDir)) continue;
+
+      const otherGates = [...gates].filter(g => g !== entryDir);
+
+      if (isLastCell) {
+        if (otherGates.length !== 1) continue;
+        const exitGate = otherGates[0];
+        const [er, ec] = getNeighbor(nextRow, nextCol, exitGate);
+        if (isValidPos(er, ec, gridSize)) continue;
+        validCandidates.push({ stage, exitDir: exitGate });
+      } else {
+        if (otherGates.length !== 1) continue;
+        const exitGate = otherGates[0];
+        const [er, ec] = getNeighbor(nextRow, nextCol, exitGate);
+        if (!isValidPos(er, ec, gridSize)) continue;
+        if (grid[er][ec].stageName) continue;
+        validCandidates.push({ stage, exitDir: exitGate });
+      }
+    }
+
+    if (validCandidates.length === 0) {
+      // Try to end early if we have enough cells
+      if (path.length >= 3) {
+        for (const stage of candidateStages) {
+          const gates = getOriginalGates(stage);
+          if (!gates.has(entryDir)) continue;
+          const otherGates = [...gates].filter(g => g !== entryDir);
+          if (otherGates.length !== 1) continue;
+          const exitGate = otherGates[0];
+          const [er, ec] = getNeighbor(nextRow, nextCol, exitGate);
+          if (!isValidPos(er, ec, gridSize)) {
+            grid[nextRow][nextCol] = {
+              stageName: stage,
+              rotation: 0,
+              entryDirection: entryDir,
+              isKeyGate: false,
+              keyGateDirection: exitGate,
+              hasKey: false,
+              keyForCell: null,
+              isStart: false,
+              isEnd: true,
+              isBranch: false,
+              pathOrder: path.length,
+            };
+            path.push([nextRow, nextCol]);
+            break;
+          }
+        }
+      }
+      break;
+    }
+
+    const chosen = validCandidates[Math.floor(Math.random() * validCandidates.length)];
+
+    grid[nextRow][nextCol] = {
+      stageName: chosen.stage,
+      rotation: 0,
+      entryDirection: entryDir,
+      isKeyGate: false,
+      keyGateDirection: isLastCell ? chosen.exitDir : null,
+      hasKey: false,
+      keyForCell: null,
+      isStart: false,
+      isEnd: isLastCell,
+      isBranch: false,
+      pathOrder: path.length,
+    };
+    path.push([nextRow, nextCol]);
+
+    if (isLastCell || !chosen.exitDir) break;
+    currentRow = nextRow;
+    currentCol = nextCol;
+    lastExitDir = chosen.exitDir;
+  }
+
+  if (path.length < 3) return null;
+
+  // Fix end cell if needed
+  const [endRow, endCol] = path[path.length - 1];
+  const endCell = grid[endRow][endCol];
+
+  if (!endCell.isEnd || !endCell.keyGateDirection) {
+    const entryDir = endCell.entryDirection;
+    if (!entryDir) return null;
+
+    let foundValidEnd = false;
+    for (const stage of candidateStages) {
+      if (foundValidEnd) break;
+      const gates = getOriginalGates(stage);
+      if (!gates.has(entryDir)) continue;
+
+      let warpDir: Direction | null = null;
+      let hasOrphan = false;
+      for (const gate of gates) {
+        if (gate === entryDir) continue;
+        const [nr, nc] = getNeighbor(endRow, endCol, gate);
+        if (!isValidPos(nr, nc, gridSize)) {
+          warpDir = gate;
+        } else if (grid[nr][nc].stageName) {
+          const neighborGates = getOriginalGates(grid[nr][nc].stageName!);
+          if (!neighborGates.has(oppositeDirection(gate))) {
+            hasOrphan = true;
+            break;
+          }
+        }
+      }
+
+      if (hasOrphan || !warpDir) continue;
+
+      grid[endRow][endCol] = {
+        ...endCell,
+        stageName: stage,
+        isEnd: true,
+        keyGateDirection: warpDir,
+      };
+      foundValidEnd = true;
+    }
+
+    if (!foundValidEnd) return null;
+  }
+
+  // Add dead-end branches
+  const branchCells: [number, number][] = [];
+  if (branches > 0) {
+    const branchCandidates: {
+      pathCell: [number, number];
+      branchDir: Direction;
+      branchPos: [number, number];
+      needsReplacement: boolean;
+      replacementStage?: string;
+    }[] = [];
+
+    for (const [pr, pc] of path) {
+      const cell = grid[pr][pc];
+      if (cell.isStart || cell.isEnd) continue;
+
+      const currentGates = getOriginalGates(cell.stageName!);
+      const exitDir = [...currentGates].find(g => g !== cell.entryDirection);
+      if (!exitDir) continue;
+
+      const directions: Direction[] = ['north', 'south', 'east', 'west'];
+      for (const dir of directions) {
+        if (dir === cell.entryDirection || dir === exitDir) continue;
+
+        const [br, bc] = getNeighbor(pr, pc, dir);
+        if (!isValidPos(br, bc, gridSize)) continue;
+        if (grid[br][bc].stageName) continue;
+
+        if (currentGates.has(dir)) {
+          branchCandidates.push({
+            pathCell: [pr, pc],
+            branchDir: dir,
+            branchPos: [br, bc],
+            needsReplacement: false,
+          });
+        } else {
+          for (const stage of candidateStages) {
+            const gates = getOriginalGates(stage);
+            if (!gates.has(cell.entryDirection!)) continue;
+            if (!gates.has(exitDir)) continue;
+            if (!gates.has(dir)) continue;
+
+            let valid = true;
+            for (const gate of gates) {
+              if (gate === cell.entryDirection || gate === exitDir || gate === dir) continue;
+              const [nr, nc] = getNeighbor(pr, pc, gate);
+              if (isValidPos(nr, nc, gridSize) && grid[nr][nc].stageName) {
+                valid = false;
+                break;
+              }
+            }
+            if (!valid) continue;
+
+            branchCandidates.push({
+              pathCell: [pr, pc],
+              branchDir: dir,
+              branchPos: [br, bc],
+              needsReplacement: true,
+              replacementStage: stage,
+            });
+            break;
+          }
+        }
+      }
+    }
+
+    const shuffled = [...branchCandidates].sort(() => Math.random() - 0.5);
+    let placedBranches = 0;
+
+    for (const candidate of shuffled) {
+      if (placedBranches >= branches) break;
+      const { pathCell, branchDir, branchPos, needsReplacement, replacementStage } = candidate;
+      const [pr, pc] = pathCell;
+      const [br, bc] = branchPos;
+
+      if (grid[br][bc].stageName) continue;
+
+      if (needsReplacement && replacementStage) {
+        const oldCell = grid[pr][pc];
+        grid[pr][pc] = { ...oldCell, stageName: replacementStage };
+      }
+
+      const branchEntry = oppositeDirection(branchDir);
+      const shuffledStages = [...candidateStages].sort(() => Math.random() - 0.5);
+
+      let placed = false;
+      for (const stage of shuffledStages) {
+        if (placed) break;
+        const gates = getOriginalGates(stage);
+        if (gates.size !== 1) continue;
+        // Try rotations [0, 90, 180, 270] to match the single gate to branchEntry
+        for (const rot of [0, 90, 180, 270]) {
+          const rotatedGate = rotateDirection([...gates][0], rot);
+          if (rotatedGate !== branchEntry) continue;
+
+          grid[br][bc] = {
+            stageName: stage,
+            rotation: rot,
+            entryDirection: branchEntry,
+            isKeyGate: false,
+            keyGateDirection: null,
+            hasKey: false,
+            keyForCell: null,
+            isStart: false,
+            isEnd: false,
+            isBranch: true,
+            pathOrder: -1,
+          };
+          branchCells.push([br, bc]);
+          placedBranches++;
+          placed = true;
+          break;
+        }
+      }
+    }
+  }
+
+  // Place key-gates and keys
+  const keyLinks: Record<string, string> = {};
+  if (keyGates > 0) {
+    const branchToPathOrder = new Map<string, number>();
+    for (const [br, bc] of branchCells) {
+      const branchCell = grid[br][bc];
+      const entryDir = branchCell.entryDirection;
+      if (!entryDir) continue;
+      const [pr, pc] = getNeighbor(br, bc, entryDir);
+      if (isValidPos(pr, pc, gridSize) && grid[pr][pc].stageName) {
+        branchToPathOrder.set(`${br},${bc}`, grid[pr][pc].pathOrder);
+      }
+    }
+
+    const keyGateCandidates = path.slice(3).filter(([r, c]) => !grid[r][c].isEnd);
+    const shuffledGateCells = [...keyGateCandidates].sort(() => Math.random() - 0.5);
+
+    let placed = 0;
+    for (const [gateRow, gateCol] of shuffledGateCells) {
+      if (placed >= keyGates) break;
+
+      const gateCell = grid[gateRow][gateCol];
+      const gatePathOrder = gateCell.pathOrder;
+
+      const mainPathCandidates = path.filter(([r, c]) => {
+        const cell = grid[r][c];
+        return cell.pathOrder < gatePathOrder && cell.pathOrder > 0 && !cell.hasKey && !cell.isKeyGate;
+      });
+
+      const branchKeyCandidates = branchCells.filter(([br, bc]) => {
+        const cell = grid[br][bc];
+        if (cell.hasKey) return false;
+        const order = branchToPathOrder.get(`${br},${bc}`);
+        return order !== undefined && order < gatePathOrder;
+      });
+
+      let keyCandidates: [number, number][];
+      if (branchKeyCandidates.length > 0 && Math.random() < 0.8) {
+        keyCandidates = branchKeyCandidates;
+      } else if (mainPathCandidates.length > 0) {
+        keyCandidates = mainPathCandidates;
+      } else if (branchKeyCandidates.length > 0) {
+        keyCandidates = branchKeyCandidates;
+      } else {
+        continue;
+      }
+
+      const [keyRow, keyCol] = keyCandidates[Math.floor(Math.random() * keyCandidates.length)];
+
+      const gates = getOriginalGates(gateCell.stageName!);
+      const exitGates = [...gates].filter(g => g !== gateCell.entryDirection);
+      if (exitGates.length === 0) continue;
+
+      const lockedDir = exitGates[Math.floor(Math.random() * exitGates.length)];
+
+      gateCell.isKeyGate = true;
+      gateCell.keyGateDirection = lockedDir;
+      grid[keyRow][keyCol].hasKey = true;
+      grid[keyRow][keyCol].keyForCell = [gateRow, gateCol];
+
+      keyLinks[`${gateRow},${gateCol}`] = `${keyRow},${keyCol}`;
+      placed++;
+    }
+  }
+
+  // Validate all gate connections
+  for (let r = 0; r < gridSize; r++) {
+    for (let c = 0; c < gridSize; c++) {
+      const cell = grid[r][c];
+      if (!cell.stageName) continue;
+
+      const gates = getRotatedGates(cell.stageName, cell.rotation);
+      for (const dir of gates) {
+        const [nr, nc] = getNeighbor(r, c, dir);
+        if (!isValidPos(nr, nc, gridSize)) continue;
+
+        const neighbor = grid[nr][nc];
+        if (!neighbor.stageName) return null;
+
+        const neighborGates = getRotatedGates(neighbor.stageName, neighbor.rotation);
+        if (!neighborGates.has(oppositeDirection(dir))) return null;
+      }
+    }
+  }
+
+  // BFS validation — ensure end is reachable
+  const simVisited = new Set<string>();
+  const simKeys = new Set<string>();
+  const simQueue: [number, number][] = [[sa1Row, sa1Col]];
+
+  while (simQueue.length > 0) {
+    const [r, c] = simQueue.shift()!;
+    const key = `${r},${c}`;
+    if (simVisited.has(key)) continue;
+    simVisited.add(key);
+
+    const cell = grid[r][c];
+    if (!cell.stageName) continue;
+
+    if (cell.hasKey && cell.keyForCell) {
+      simKeys.add(`${cell.keyForCell[0]},${cell.keyForCell[1]}`);
+    }
+
+    const gates = getRotatedGates(cell.stageName, cell.rotation);
+    for (const dir of gates) {
+      if (cell.isKeyGate && cell.keyGateDirection === dir && !simKeys.has(key)) continue;
+
+      const [nr, nc] = getNeighbor(r, c, dir);
+      if (!isValidPos(nr, nc, gridSize)) continue;
+
+      const neighbor = grid[nr][nc];
+      if (!neighbor.stageName) continue;
+      if (simVisited.has(`${nr},${nc}`)) continue;
+
+      const neighborGates = getRotatedGates(neighbor.stageName, neighbor.rotation);
+      if (!neighborGates.has(oppositeDirection(dir))) continue;
+
+      simQueue.push([nr, nc]);
+    }
+  }
+
+  if (!simVisited.has(`${endRow},${endCol}`)) return null;
+
+  // Convert to EditorGridCell map
+  const cells: Record<string, EditorGridCell> = {};
+  let startPos: string | null = null;
+  let endPos: string | null = null;
+
+  for (let r = 0; r < gridSize; r++) {
+    for (let c = 0; c < gridSize; c++) {
+      const cell = grid[r][c];
+      if (!cell.stageName) continue;
+
+      const pos = `${r},${c}`;
+      let role: CellRole = 'transit';
+      if (cell.isEnd) role = 'boss';
+      if (cell.isStart) startPos = pos;
+      if (cell.isEnd) endPos = pos;
+
+      cells[pos] = {
+        stageName: cell.stageName,
+        rotation: cell.rotation || undefined,
+        role,
+        manual: false,
+      };
+    }
+  }
+
+  return {
+    cells,
+    startPos,
+    endPos,
+    keyLinks,
+    pathLength: path.length,
+  };
+}

--- a/src/components/quest-editor/tabs/ContentTab.tsx
+++ b/src/components/quest-editor/tabs/ContentTab.tsx
@@ -10,8 +10,8 @@ import { useState, useCallback, useMemo, useRef, Suspense } from 'react';
 import { Canvas, useThree, useFrame } from '@react-three/fiber';
 import { OrbitControls, useGLTF, Grid } from '@react-three/drei';
 import * as THREE from 'three';
-import type { QuestProject, Direction } from '../types';
-import { ROLE_COLORS } from '../types';
+import type { QuestProject, Direction, CellObject, CellObjectType } from '../types';
+import { ROLE_COLORS, CELL_OBJECT_COLORS, CELL_OBJECT_LABELS } from '../types';
 import { getRotatedGates, getStageConfig, getStageSuffix } from '../hooks/useStageConfigs';
 import { getGlbPath, getAreaFromMapId } from '../../stage-editor/constants';
 import type { GateConfig } from '../../../systems/stage/types';
@@ -109,6 +109,173 @@ function SpawnMarker({ position, edge }: { position: [number, number, number]; e
         </mesh>
       </group>
     </group>
+  );
+}
+
+// ============================================================================
+// Object Markers (3D representations of placed objects)
+// ============================================================================
+
+/** Box marker — brown/gold cube */
+function BoxMarker({ obj, selected, onClick }: { obj: CellObject; selected: boolean; onClick: () => void }) {
+  const color = obj.type === 'rare_box' ? '#ddaa33' : '#aa6633';
+  return (
+    <group position={obj.position} onClick={(e) => { e.stopPropagation(); onClick(); }}>
+      <mesh position={[0, 0.5, 0]}>
+        <boxGeometry args={[1, 1, 1]} />
+        <meshBasicMaterial color={color} transparent opacity={selected ? 0.9 : 0.6} />
+      </mesh>
+      <lineSegments position={[0, 0.5, 0]}>
+        <edgesGeometry args={[new THREE.BoxGeometry(1, 1, 1)]} />
+        <lineBasicMaterial color={selected ? '#ffffff' : color} />
+      </lineSegments>
+    </group>
+  );
+}
+
+/** Enemy marker — red sphere with label */
+function EnemyMarker({ obj, selected, onClick }: { obj: CellObject; selected: boolean; onClick: () => void }) {
+  return (
+    <group position={obj.position} onClick={(e) => { e.stopPropagation(); onClick(); }}>
+      <mesh position={[0, 0.8, 0]}>
+        <sphereGeometry args={[0.8, 16, 16]} />
+        <meshBasicMaterial color="#cc4444" transparent opacity={selected ? 0.9 : 0.5} />
+      </mesh>
+      {selected && (
+        <mesh position={[0, 0.8, 0]}>
+          <sphereGeometry args={[0.9, 16, 16]} />
+          <meshBasicMaterial color="#ffffff" wireframe transparent opacity={0.4} />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+/** Fence marker — blue horizontal bar */
+function FenceMarker({ obj, selected, onClick }: { obj: CellObject; selected: boolean; onClick: () => void }) {
+  const yRot = ((obj.rotation || 0) * Math.PI) / 180;
+  return (
+    <group position={obj.position} rotation={[0, yRot, 0]} onClick={(e) => { e.stopPropagation(); onClick(); }}>
+      <mesh position={[0, 1, 0]}>
+        <boxGeometry args={[3, 2, 0.3]} />
+        <meshBasicMaterial color="#4488cc" transparent opacity={selected ? 0.7 : 0.4} />
+      </mesh>
+      <lineSegments position={[0, 1, 0]}>
+        <edgesGeometry args={[new THREE.BoxGeometry(3, 2, 0.3)]} />
+        <lineBasicMaterial color={selected ? '#ffffff' : '#4488cc'} />
+      </lineSegments>
+    </group>
+  );
+}
+
+/** Switch marker — green flat disc */
+function SwitchMarker({ obj, selected, onClick }: { obj: CellObject; selected: boolean; onClick: () => void }) {
+  return (
+    <group position={obj.position} onClick={(e) => { e.stopPropagation(); onClick(); }}>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.05, 0]}>
+        <cylinderGeometry args={[0.8, 0.8, 0.1, 16]} />
+        <meshBasicMaterial color="#44cc66" transparent opacity={selected ? 0.9 : 0.5} />
+      </mesh>
+      {selected && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.06, 0]}>
+          <ringGeometry args={[0.9, 1.1, 16]} />
+          <meshBasicMaterial color="#ffffff" side={THREE.DoubleSide} transparent opacity={0.5} />
+        </mesh>
+      )}
+    </group>
+  );
+}
+
+/** Renders the appropriate marker for a CellObject */
+function ObjectMarker({ obj, selected, onClick }: { obj: CellObject; selected: boolean; onClick: () => void }) {
+  switch (obj.type) {
+    case 'box':
+    case 'rare_box':
+      return <BoxMarker obj={obj} selected={selected} onClick={onClick} />;
+    case 'enemy':
+      return <EnemyMarker obj={obj} selected={selected} onClick={onClick} />;
+    case 'fence':
+      return <FenceMarker obj={obj} selected={selected} onClick={onClick} />;
+    case 'step_switch':
+      return <SwitchMarker obj={obj} selected={selected} onClick={onClick} />;
+    default:
+      return null;
+  }
+}
+
+/** Object placement cursor — follows mouse on ground plane */
+function ObjectPlacementCursor({ objectType }: { objectType: CellObjectType }) {
+  const { camera, raycaster, pointer } = useThree();
+  const groupRef = useRef<THREE.Group>(null);
+  const groundPlane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), 0), []);
+  const intersection = useMemo(() => new THREE.Vector3(), []);
+  const color = CELL_OBJECT_COLORS[objectType];
+
+  useFrame(() => {
+    if (!groupRef.current) return;
+    raycaster.setFromCamera(pointer, camera);
+    if (raycaster.ray.intersectPlane(groundPlane, intersection)) {
+      groupRef.current.position.set(intersection.x, 0, intersection.z);
+    }
+  });
+
+  return (
+    <group ref={groupRef}>
+      {(objectType === 'box' || objectType === 'rare_box') && (
+        <mesh position={[0, 0.5, 0]}>
+          <boxGeometry args={[1, 1, 1]} />
+          <meshBasicMaterial color={color} transparent opacity={0.3} />
+        </mesh>
+      )}
+      {objectType === 'enemy' && (
+        <mesh position={[0, 0.8, 0]}>
+          <sphereGeometry args={[0.8, 16, 16]} />
+          <meshBasicMaterial color={color} transparent opacity={0.3} />
+        </mesh>
+      )}
+      {objectType === 'fence' && (
+        <mesh position={[0, 1, 0]}>
+          <boxGeometry args={[3, 2, 0.3]} />
+          <meshBasicMaterial color={color} transparent opacity={0.3} />
+        </mesh>
+      )}
+      {objectType === 'step_switch' && (
+        <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.05, 0]}>
+          <cylinderGeometry args={[0.8, 0.8, 0.1, 16]} />
+          <meshBasicMaterial color={color} transparent opacity={0.3} />
+        </mesh>
+      )}
+      {/* Ground ring */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.02, 0]}>
+        <ringGeometry args={[1.2, 1.5, 32]} />
+        <meshBasicMaterial color={color} side={THREE.DoubleSide} transparent opacity={0.3} />
+      </mesh>
+    </group>
+  );
+}
+
+/** Ground click handler for object placement */
+function ObjectClickPlane({ onPlace }: { onPlace: (pos: [number, number, number]) => void }) {
+  const { camera, raycaster, pointer } = useThree();
+  const groundPlane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), 0), []);
+  const intersection = useMemo(() => new THREE.Vector3(), []);
+
+  const handleClick = useCallback(() => {
+    raycaster.setFromCamera(pointer, camera);
+    if (raycaster.ray.intersectPlane(groundPlane, intersection)) {
+      onPlace([
+        Math.round(intersection.x * 10) / 10,
+        0,
+        Math.round(intersection.z * 10) / 10,
+      ]);
+    }
+  }, [raycaster, pointer, camera, groundPlane, intersection, onPlace]);
+
+  return (
+    <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, 0.01, 0]} onClick={handleClick}>
+      <planeGeometry args={[200, 200]} />
+      <meshBasicMaterial transparent opacity={0} side={THREE.DoubleSide} />
+    </mesh>
   );
 }
 
@@ -213,6 +380,7 @@ function MiniGrid({
             const hasKey = Object.values(project.keyLinks).includes(pos);
             const isKeyGate = pos in project.keyLinks;
             const hasKeyPosition = cell?.keyPosition != null;
+            const hasObjects = (cell?.objects?.length || 0) > 0;
 
             if (!cell) {
               return (
@@ -251,6 +419,7 @@ function MiniGrid({
                 {isEnd && <div style={{ position: 'absolute', top: 1, left: 1, width: 6, height: 6, background: '#ffaa66', borderRadius: '50%' }} />}
                 {hasKey && <div style={{ position: 'absolute', top: 1, right: 1, width: 6, height: 6, background: hasKeyPosition ? '#88ff88' : '#ff66aa', borderRadius: '50%' }} />}
                 {isKeyGate && <div style={{ position: 'absolute', bottom: 1, right: 1, width: 6, height: 6, background: '#ff66ff', borderRadius: 1 }} />}
+                {hasObjects && <div style={{ position: 'absolute', bottom: 1, left: 1, width: 6, height: 6, background: '#ffaa33', borderRadius: '50%' }} />}
               </div>
             );
           })}
@@ -271,6 +440,12 @@ function CellContentInspector({
   onTogglePlaceKey,
   onClearKeyPosition,
   onSetKeyPosition,
+  placingObject,
+  onSetPlacingObject,
+  selectedObjectId,
+  onSelectObject,
+  onDeleteObject,
+  onUpdateObject,
 }: {
   project: QuestProject;
   selectedCell: string;
@@ -278,6 +453,12 @@ function CellContentInspector({
   onTogglePlaceKey: () => void;
   onClearKeyPosition: () => void;
   onSetKeyPosition: (pos: [number, number, number]) => void;
+  placingObject: CellObjectType | null;
+  onSetPlacingObject: (type: CellObjectType | null) => void;
+  selectedObjectId: string | null;
+  onSelectObject: (id: string | null) => void;
+  onDeleteObject: (id: string) => void;
+  onUpdateObject: (id: string, updates: Partial<CellObject>) => void;
 }) {
   const cell = project.cells[selectedCell];
   if (!cell) {
@@ -430,6 +611,129 @@ function CellContentInspector({
         </div>
       )}
 
+      {/* Objects */}
+      <div style={sectionStyle}>
+        <div style={labelStyle}>Objects ({cell.objects?.length || 0})</div>
+
+        {/* Object palette */}
+        <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap', marginBottom: '8px' }}>
+          {(['box', 'rare_box', 'enemy', 'fence', 'step_switch'] as CellObjectType[]).map(type => (
+            <button
+              key={type}
+              onClick={() => onSetPlacingObject(placingObject === type ? null : type)}
+              style={{
+                ...btnStyle,
+                padding: '4px 8px',
+                fontSize: '10px',
+                background: placingObject === type ? CELL_OBJECT_COLORS[type] : '#2a2a4a',
+                border: `1px solid ${CELL_OBJECT_COLORS[type]}`,
+                color: placingObject === type ? '#fff' : CELL_OBJECT_COLORS[type],
+              }}
+            >
+              + {CELL_OBJECT_LABELS[type]}
+            </button>
+          ))}
+        </div>
+
+        {placingObject && (
+          <div style={{ fontSize: '11px', color: CELL_OBJECT_COLORS[placingObject], marginBottom: '8px' }}>
+            Click in 3D view to place {CELL_OBJECT_LABELS[placingObject]}
+          </div>
+        )}
+
+        {/* Object list */}
+        {cell.objects && cell.objects.length > 0 && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            {cell.objects.map(obj => {
+              const isSel = selectedObjectId === obj.id;
+              return (
+                <div
+                  key={obj.id}
+                  onClick={() => onSelectObject(isSel ? null : obj.id)}
+                  style={{
+                    padding: '6px 8px',
+                    background: isSel ? '#3a3a6a' : '#222',
+                    border: `1px solid ${isSel ? '#88aaff' : CELL_OBJECT_COLORS[obj.type]}`,
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                  }}
+                >
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <span style={{ fontSize: '11px', color: CELL_OBJECT_COLORS[obj.type], fontWeight: 600 }}>
+                      {CELL_OBJECT_LABELS[obj.type]}
+                    </span>
+                    <button
+                      onClick={(e) => { e.stopPropagation(); onDeleteObject(obj.id); }}
+                      style={{ ...btnStyle, padding: '2px 6px', fontSize: '9px', background: '#884444' }}
+                    >
+                      DEL
+                    </button>
+                  </div>
+                  <div style={{ fontSize: '10px', color: '#888', fontFamily: 'monospace', marginTop: '2px' }}>
+                    [{obj.position[0]}, {obj.position[1]}, {obj.position[2]}]
+                  </div>
+
+                  {/* Enemy ID picker */}
+                  {isSel && obj.type === 'enemy' && (
+                    <div style={{ marginTop: '4px' }}>
+                      <input
+                        type="text"
+                        value={obj.enemy_id || ''}
+                        onChange={(e) => onUpdateObject(obj.id, { enemy_id: e.target.value || undefined })}
+                        placeholder="enemy_id (e.g. lizard)"
+                        onClick={(e) => e.stopPropagation()}
+                        style={{
+                          width: '100%', padding: '4px', background: '#111',
+                          border: '1px solid #444', borderRadius: '3px',
+                          color: '#fff', fontSize: '11px', fontFamily: 'monospace',
+                        }}
+                      />
+                    </div>
+                  )}
+
+                  {/* Link ID for fences and switches */}
+                  {isSel && (obj.type === 'fence' || obj.type === 'step_switch') && (
+                    <div style={{ marginTop: '4px' }}>
+                      <input
+                        type="text"
+                        value={obj.link_id || ''}
+                        onChange={(e) => onUpdateObject(obj.id, { link_id: e.target.value || undefined })}
+                        placeholder="link_id (e.g. a)"
+                        onClick={(e) => e.stopPropagation()}
+                        style={{
+                          width: '100%', padding: '4px', background: '#111',
+                          border: '1px solid #444', borderRadius: '3px',
+                          color: '#fff', fontSize: '11px', fontFamily: 'monospace',
+                        }}
+                      />
+                    </div>
+                  )}
+
+                  {/* Rotation for fences */}
+                  {isSel && obj.type === 'fence' && (
+                    <div style={{ marginTop: '4px', display: 'flex', gap: '4px', alignItems: 'center' }}>
+                      <span style={{ fontSize: '10px', color: '#888' }}>Rot:</span>
+                      {[0, 90].map(deg => (
+                        <button
+                          key={deg}
+                          onClick={(e) => { e.stopPropagation(); onUpdateObject(obj.id, { rotation: deg || undefined }); }}
+                          style={{
+                            ...btnStyle, padding: '2px 6px', fontSize: '9px',
+                            background: (obj.rotation || 0) === deg ? '#4488cc' : '#333',
+                          }}
+                        >
+                          {deg}&deg;
+                        </button>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
       {/* Notes */}
       {cell.notes && (
         <div style={sectionStyle}>
@@ -483,6 +787,8 @@ function badgeStyle(color: string): React.CSSProperties {
 export default function ContentTab({ project, onUpdateProject }: ContentTabProps) {
   const [selectedCell, setSelectedCell] = useState<string | null>(null);
   const [placingKey, setPlacingKey] = useState(false);
+  const [placingObject, setPlacingObject] = useState<CellObjectType | null>(null);
+  const [selectedObjectId, setSelectedObjectId] = useState<string | null>(null);
 
   const cell = selectedCell ? project.cells[selectedCell] : null;
   const config = cell ? getStageConfig(cell.stageName) : null;
@@ -514,12 +820,79 @@ export default function ContentTab({ project, onUpdateProject }: ContentTabProps
 
   const handleTogglePlaceKey = useCallback(() => {
     setPlacingKey(p => !p);
+    setPlacingObject(null);
   }, []);
+
+  const handleSetPlacingObject = useCallback((type: CellObjectType | null) => {
+    setPlacingObject(type);
+    setPlacingKey(false);
+  }, []);
+
+  const handlePlaceObject = useCallback((pos: [number, number, number]) => {
+    if (!selectedCell || !placingObject) return;
+    onUpdateProject(prev => {
+      const cellData = prev.cells[selectedCell];
+      const objects = [...(cellData.objects || [])];
+      const typeCount = objects.filter(o => o.type === placingObject).length;
+      const newObj: CellObject = {
+        id: `${placingObject}_${typeCount}`,
+        type: placingObject,
+        position: pos,
+      };
+      if (placingObject === 'enemy') newObj.enemy_id = 'lizard';
+      return {
+        ...prev,
+        cells: {
+          ...prev.cells,
+          [selectedCell]: { ...cellData, objects: [...objects, newObj] },
+        },
+      };
+    });
+  }, [selectedCell, placingObject, onUpdateProject]);
+
+  const handleDeleteObject = useCallback((objId: string) => {
+    if (!selectedCell) return;
+    onUpdateProject(prev => {
+      const cellData = prev.cells[selectedCell];
+      return {
+        ...prev,
+        cells: {
+          ...prev.cells,
+          [selectedCell]: {
+            ...cellData,
+            objects: (cellData.objects || []).filter(o => o.id !== objId),
+          },
+        },
+      };
+    });
+    if (selectedObjectId === objId) setSelectedObjectId(null);
+  }, [selectedCell, selectedObjectId, onUpdateProject]);
+
+  const handleUpdateObject = useCallback((objId: string, updates: Partial<CellObject>) => {
+    if (!selectedCell) return;
+    onUpdateProject(prev => {
+      const cellData = prev.cells[selectedCell];
+      return {
+        ...prev,
+        cells: {
+          ...prev.cells,
+          [selectedCell]: {
+            ...cellData,
+            objects: (cellData.objects || []).map(o =>
+              o.id === objId ? { ...o, ...updates } : o
+            ),
+          },
+        },
+      };
+    });
+  }, [selectedCell, onUpdateProject]);
 
   // Select first cell with a key if none selected
   const handleCellSelect = useCallback((pos: string) => {
     setSelectedCell(pos);
     setPlacingKey(false);
+    setPlacingObject(null);
+    setSelectedObjectId(null);
   }, []);
 
   return (
@@ -602,11 +975,29 @@ export default function ContentTab({ project, onUpdateProject }: ContentTabProps
                 <KeyMarker position={cell.keyPosition} />
               )}
 
+              {/* Object markers */}
+              {cell.objects?.map(obj => (
+                <ObjectMarker
+                  key={obj.id}
+                  obj={obj}
+                  selected={selectedObjectId === obj.id}
+                  onClick={() => setSelectedObjectId(prev => prev === obj.id ? null : obj.id)}
+                />
+              ))}
+
               {/* Key placement mode */}
               {placingKey && (
                 <>
                   <KeyPlacementCursor />
                   <GroundClickPlane onPlace={handlePlaceKey} />
+                </>
+              )}
+
+              {/* Object placement mode */}
+              {placingObject && (
+                <>
+                  <ObjectPlacementCursor objectType={placingObject} />
+                  <ObjectClickPlane onPlace={handlePlaceObject} />
                 </>
               )}
 
@@ -633,6 +1024,19 @@ export default function ContentTab({ project, onUpdateProject }: ContentTabProps
               onClick={() => setPlacingKey(false)}
               >
                 Click in 3D view to place key | ESC to cancel
+              </div>
+            )}
+
+            {placingObject && (
+              <div style={{
+                position: 'absolute', bottom: 12, left: '50%', transform: 'translateX(-50%)',
+                background: CELL_OBJECT_COLORS[placingObject], padding: '8px 20px',
+                borderRadius: '20px', fontSize: '13px', color: '#fff', fontWeight: 600,
+                cursor: 'pointer',
+              }}
+              onClick={() => setPlacingObject(null)}
+              >
+                Click to place {CELL_OBJECT_LABELS[placingObject]} | Click here to cancel
               </div>
             )}
           </>
@@ -663,6 +1067,12 @@ export default function ContentTab({ project, onUpdateProject }: ContentTabProps
             onTogglePlaceKey={handleTogglePlaceKey}
             onClearKeyPosition={handleClearKeyPosition}
             onSetKeyPosition={handlePlaceKey}
+            placingObject={placingObject}
+            onSetPlacingObject={handleSetPlacingObject}
+            selectedObjectId={selectedObjectId}
+            onSelectObject={setSelectedObjectId}
+            onDeleteObject={handleDeleteObject}
+            onUpdateObject={handleUpdateObject}
           />
         ) : (
           <div style={{ padding: '1rem', color: '#888', fontSize: '13px' }}>

--- a/src/components/quest-editor/tabs/ContentTab.tsx
+++ b/src/components/quest-editor/tabs/ContentTab.tsx
@@ -1,0 +1,676 @@
+/**
+ * ContentTab — 3D cell preview with key/gate placement
+ *
+ * Left: Mini grid for cell selection
+ * Center: 3D StageCanvas showing the selected cell's GLB
+ * Right: Cell content inspector (key position, gate info)
+ */
+
+import { useState, useCallback, useMemo, useRef, Suspense } from 'react';
+import { Canvas, useThree, useFrame } from '@react-three/fiber';
+import { OrbitControls, useGLTF, Grid } from '@react-three/drei';
+import * as THREE from 'three';
+import type { QuestProject, Direction } from '../types';
+import { ROLE_COLORS } from '../types';
+import { getRotatedGates, getStageConfig, getStageSuffix } from '../hooks/useStageConfigs';
+import { getGlbPath, getAreaFromMapId } from '../../stage-editor/constants';
+import type { GateConfig } from '../../../systems/stage/types';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ContentTabProps {
+  project: QuestProject;
+  onUpdateProject: (updater: (prev: QuestProject) => QuestProject) => void;
+}
+
+// ============================================================================
+// 3D Marker components
+// ============================================================================
+
+/** Gate marker — cyan wireframe box at gate position */
+function GateMarker({ gate, isLocked }: { gate: GateConfig; isLocked: boolean }) {
+  const boxWidth = 6;
+  const boxHeight = 4;
+  const boxDepth = 1;
+  const color = isLocked ? '#ff66ff' : '#00ffff';
+
+  // Rotation based on gate edge
+  const rotation = gate.edge === 'north' ? Math.PI
+    : gate.edge === 'south' ? 0
+    : gate.edge === 'east' ? Math.PI / 2
+    : -Math.PI / 2;
+
+  return (
+    <group position={[gate.x, 0, gate.z]} rotation={[0, rotation, 0]}>
+      <mesh position={[0, boxHeight / 2, 0]}>
+        <boxGeometry args={[boxWidth, boxHeight, boxDepth]} />
+        <meshBasicMaterial color={color} transparent opacity={0.2} />
+      </mesh>
+      <lineSegments position={[0, boxHeight / 2, 0]}>
+        <edgesGeometry args={[new THREE.BoxGeometry(boxWidth, boxHeight, boxDepth)]} />
+        <lineBasicMaterial color={color} />
+      </lineSegments>
+      {/* Label */}
+      <mesh position={[0, boxHeight + 0.5, 0]}>
+        <sphereGeometry args={[0.3, 8, 8]} />
+        <meshBasicMaterial color={color} />
+      </mesh>
+    </group>
+  );
+}
+
+/** Key marker — pink sphere that shows authored key position */
+function KeyMarker({ position }: { position: [number, number, number] }) {
+  return (
+    <group position={position}>
+      {/* Main sphere */}
+      <mesh>
+        <sphereGeometry args={[1.0, 16, 16]} />
+        <meshBasicMaterial color="#ff66aa" transparent opacity={0.8} />
+      </mesh>
+      {/* Ring on ground */}
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -position[1] + 0.05, 0]}>
+        <ringGeometry args={[1.2, 1.5, 32]} />
+        <meshBasicMaterial color="#ff66aa" side={THREE.DoubleSide} transparent opacity={0.5} />
+      </mesh>
+      {/* Vertical line to ground */}
+      <mesh position={[0, -position[1] / 2, 0]}>
+        <cylinderGeometry args={[0.05, 0.05, position[1], 8]} />
+        <meshBasicMaterial color="#ff66aa" transparent opacity={0.4} />
+      </mesh>
+    </group>
+  );
+}
+
+/** Spawn point marker — green sphere with arrow */
+function SpawnMarker({ position, edge }: { position: [number, number, number]; edge: string }) {
+  const rotation = edge === 'north' ? Math.PI
+    : edge === 'south' ? 0
+    : edge === 'east' ? Math.PI / 2
+    : -Math.PI / 2;
+
+  return (
+    <group position={position}>
+      <mesh>
+        <sphereGeometry args={[0.6, 16, 16]} />
+        <meshBasicMaterial color="#00ff00" transparent opacity={0.5} />
+      </mesh>
+      {/* Direction arrow */}
+      <group rotation={[0, rotation, 0]}>
+        <mesh position={[0, 0.3, 1]}>
+          <boxGeometry args={[0.15, 0.15, 1.0]} />
+          <meshBasicMaterial color="#00ff00" transparent opacity={0.5} />
+        </mesh>
+        <mesh position={[0, 0.3, 1.8]} rotation={[Math.PI / 2, 0, 0]}>
+          <coneGeometry args={[0.3, 0.5, 8]} />
+          <meshBasicMaterial color="#00ff00" transparent opacity={0.5} />
+        </mesh>
+      </group>
+    </group>
+  );
+}
+
+/** Placement cursor — follows mouse, shows where key will be placed */
+function KeyPlacementCursor() {
+  const { camera, raycaster, pointer } = useThree();
+  const groupRef = useRef<THREE.Group>(null);
+  const groundPlane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), -1), []);
+  const intersection = useMemo(() => new THREE.Vector3(), []);
+
+  useFrame(() => {
+    if (!groupRef.current) return;
+    raycaster.setFromCamera(pointer, camera);
+    if (raycaster.ray.intersectPlane(groundPlane, intersection)) {
+      groupRef.current.position.set(intersection.x, 1, intersection.z);
+    }
+  });
+
+  return (
+    <group ref={groupRef}>
+      <mesh>
+        <sphereGeometry args={[1.0, 16, 16]} />
+        <meshBasicMaterial color="#ff66aa" transparent opacity={0.4} />
+      </mesh>
+      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -1 + 0.05, 0]}>
+        <ringGeometry args={[1.2, 1.5, 32]} />
+        <meshBasicMaterial color="#ff66aa" side={THREE.DoubleSide} transparent opacity={0.3} />
+      </mesh>
+    </group>
+  );
+}
+
+/** Ground click handler — invisible plane for click-to-place */
+function GroundClickPlane({ onPlace }: { onPlace: (pos: [number, number, number]) => void }) {
+  const { camera, raycaster, pointer } = useThree();
+  const groundPlane = useMemo(() => new THREE.Plane(new THREE.Vector3(0, 1, 0), -1), []);
+  const intersection = useMemo(() => new THREE.Vector3(), []);
+
+  const handleClick = useCallback(() => {
+    raycaster.setFromCamera(pointer, camera);
+    if (raycaster.ray.intersectPlane(groundPlane, intersection)) {
+      onPlace([
+        Math.round(intersection.x * 10) / 10,
+        1,
+        Math.round(intersection.z * 10) / 10,
+      ]);
+    }
+  }, [raycaster, pointer, camera, groundPlane, intersection, onPlace]);
+
+  return (
+    <mesh
+      rotation={[-Math.PI / 2, 0, 0]}
+      position={[0, 0.01, 0]}
+      onClick={handleClick}
+    >
+      <planeGeometry args={[200, 200]} />
+      <meshBasicMaterial transparent opacity={0} side={THREE.DoubleSide} />
+    </mesh>
+  );
+}
+
+/** Stage model loader */
+function StageModel({ mapId }: { mapId: string }) {
+  const areaKey = getAreaFromMapId(mapId) || 'valley';
+  const glbPath = getGlbPath(areaKey, mapId);
+  const { scene } = useGLTF(glbPath);
+  return <primitive object={scene} />;
+}
+
+// ============================================================================
+// Mini Grid (compact version for left panel)
+// ============================================================================
+
+function MiniGrid({
+  project,
+  selectedCell,
+  onCellSelect,
+}: {
+  project: QuestProject;
+  selectedCell: string | null;
+  onCellSelect: (pos: string) => void;
+}) {
+  const CELL_SIZE = 48;
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '1px',
+      background: '#111',
+      padding: '4px',
+      borderRadius: '6px',
+    }}>
+      {Array.from({ length: project.gridSize }, (_, row) => (
+        <div key={row} style={{ display: 'flex', gap: '1px' }}>
+          {Array.from({ length: project.gridSize }, (_, col) => {
+            const pos = `${row},${col}`;
+            const cell = project.cells[pos];
+            const isSelected = selectedCell === pos;
+            const isStart = project.startPos === pos;
+            const isEnd = project.endPos === pos;
+            const hasKey = Object.values(project.keyLinks).includes(pos);
+            const isKeyGate = pos in project.keyLinks;
+            const hasKeyPosition = cell?.keyPosition != null;
+
+            if (!cell) {
+              return (
+                <div key={col} style={{
+                  width: CELL_SIZE,
+                  height: CELL_SIZE,
+                  background: '#1a1a2e',
+                  border: '1px solid #222',
+                }} />
+              );
+            }
+
+            return (
+              <div
+                key={col}
+                onClick={() => onCellSelect(pos)}
+                style={{
+                  width: CELL_SIZE,
+                  height: CELL_SIZE,
+                  background: isSelected ? '#3a3a6a' : '#2a2a4a',
+                  border: `2px solid ${isSelected ? '#88aaff' : ROLE_COLORS[cell.role]}`,
+                  display: 'flex',
+                  flexDirection: 'column',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  cursor: 'pointer',
+                  position: 'relative',
+                  fontSize: '9px',
+                  color: '#fff',
+                  fontWeight: 600,
+                }}
+              >
+                {getStageSuffix(cell.stageName)}
+                {/* Badges */}
+                {isStart && <div style={{ position: 'absolute', top: 1, left: 1, width: 6, height: 6, background: '#66aaff', borderRadius: '50%' }} />}
+                {isEnd && <div style={{ position: 'absolute', top: 1, left: 1, width: 6, height: 6, background: '#ffaa66', borderRadius: '50%' }} />}
+                {hasKey && <div style={{ position: 'absolute', top: 1, right: 1, width: 6, height: 6, background: hasKeyPosition ? '#88ff88' : '#ff66aa', borderRadius: '50%' }} />}
+                {isKeyGate && <div style={{ position: 'absolute', bottom: 1, right: 1, width: 6, height: 6, background: '#ff66ff', borderRadius: 1 }} />}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// Cell Content Inspector (right panel)
+// ============================================================================
+
+function CellContentInspector({
+  project,
+  selectedCell,
+  placingKey,
+  onTogglePlaceKey,
+  onClearKeyPosition,
+  onSetKeyPosition,
+}: {
+  project: QuestProject;
+  selectedCell: string;
+  placingKey: boolean;
+  onTogglePlaceKey: () => void;
+  onClearKeyPosition: () => void;
+  onSetKeyPosition: (pos: [number, number, number]) => void;
+}) {
+  const cell = project.cells[selectedCell];
+  if (!cell) {
+    return (
+      <div style={{ padding: '1rem', color: '#888' }}>
+        <div style={labelStyle}>Empty Cell</div>
+        <p style={{ fontSize: '13px' }}>Select an occupied cell from the grid.</p>
+      </div>
+    );
+  }
+
+  const config = getStageConfig(cell.stageName);
+  const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+  const isStart = project.startPos === selectedCell;
+  const isEnd = project.endPos === selectedCell;
+  const hasKey = Object.values(project.keyLinks).includes(selectedCell);
+  const isKeyGate = selectedCell in project.keyLinks;
+  const keyPos = cell.keyPosition;
+
+  return (
+    <div style={{ padding: '1rem', overflowY: 'auto', maxHeight: 'calc(100vh - 200px)' }}>
+      {/* Header */}
+      <div style={sectionStyle}>
+        <div style={{ fontSize: '16px', fontWeight: 700, color: '#fff', marginBottom: '4px' }}>
+          {getStageSuffix(cell.stageName)}
+        </div>
+        <div style={{ fontSize: '11px', color: '#888' }}>
+          {cell.stageName} at {selectedCell}
+        </div>
+        <div style={{ display: 'flex', gap: '6px', marginTop: '6px', flexWrap: 'wrap' }}>
+          {isStart && <span style={badgeStyle('#66aaff')}>START</span>}
+          {isEnd && <span style={badgeStyle('#ffaa66')}>END</span>}
+          {hasKey && <span style={badgeStyle('#ff66aa')}>KEY</span>}
+          {isKeyGate && <span style={badgeStyle('#ff66ff')}>GATE</span>}
+          <span style={badgeStyle(ROLE_COLORS[cell.role])}>{cell.role.toUpperCase()}</span>
+        </div>
+      </div>
+
+      {/* Gate info */}
+      <div style={sectionStyle}>
+        <div style={labelStyle}>Gates ({gates.size})</div>
+        <div style={{ display: 'flex', gap: '4px', flexWrap: 'wrap' }}>
+          {(['north', 'south', 'east', 'west'] as Direction[]).map(dir => {
+            const hasGate = gates.has(dir);
+            const isLocked = cell.lockedGate === dir;
+            return (
+              <div key={dir} style={{
+                padding: '3px 8px',
+                background: isLocked ? '#ff66ff33' : hasGate ? '#00ffff22' : '#222',
+                border: `1px solid ${isLocked ? '#ff66ff' : hasGate ? '#00ffff' : '#333'}`,
+                borderRadius: '4px',
+                fontSize: '10px',
+                color: isLocked ? '#ff66ff' : hasGate ? '#00ffff' : '#555',
+                fontWeight: 600,
+              }}>
+                {dir[0].toUpperCase()}
+                {isLocked && ' locked'}
+              </div>
+            );
+          })}
+        </div>
+        {config && (
+          <div style={{ fontSize: '10px', color: '#666', marginTop: '4px' }}>
+            Grid: {config.gridSize} | Offset: [{config.gridOffset.join(', ')}]
+          </div>
+        )}
+      </div>
+
+      {/* Key placement */}
+      {hasKey && (
+        <div style={sectionStyle}>
+          <div style={labelStyle}>Key Position</div>
+          {keyPos ? (
+            <>
+              <div style={{
+                padding: '8px',
+                background: '#88ff8822',
+                border: '1px solid #88ff88',
+                borderRadius: '4px',
+                fontSize: '12px',
+                color: '#88ff88',
+                fontFamily: 'monospace',
+                marginBottom: '8px',
+              }}>
+                [{keyPos[0]}, {keyPos[1]}, {keyPos[2]}]
+              </div>
+              <div style={{ display: 'flex', gap: '6px' }}>
+                <button
+                  onClick={onTogglePlaceKey}
+                  style={{
+                    ...btnStyle,
+                    background: placingKey ? '#ff66aa' : '#555588',
+                  }}
+                >
+                  {placingKey ? 'Placing...' : 'Reposition'}
+                </button>
+                <button
+                  onClick={onClearKeyPosition}
+                  style={{ ...btnStyle, background: '#884444' }}
+                >
+                  Clear
+                </button>
+              </div>
+            </>
+          ) : (
+            <>
+              <div style={{ fontSize: '12px', color: '#ff8888', marginBottom: '8px' }}>
+                No position set. Click the 3D view to place the key.
+              </div>
+              <button
+                onClick={onTogglePlaceKey}
+                style={{
+                  ...btnStyle,
+                  background: placingKey ? '#ff66aa' : '#448844',
+                  width: '100%',
+                }}
+              >
+                {placingKey ? 'Click 3D view to place...' : 'Place Key'}
+              </button>
+            </>
+          )}
+          <div style={{ fontSize: '10px', color: '#888', marginTop: '6px' }}>
+            Unlocks: {Object.entries(project.keyLinks).find(([_, v]) => v === selectedCell)?.[0] || 'unlinked'}
+          </div>
+        </div>
+      )}
+
+      {/* Key-gate info */}
+      {isKeyGate && (
+        <div style={sectionStyle}>
+          <div style={labelStyle}>Key-Gate</div>
+          <div style={{ fontSize: '12px', color: '#cc88ff' }}>
+            Locked gate: {cell.lockedGate || 'not set'}
+          </div>
+          <div style={{ fontSize: '12px', color: '#cc88ff', marginTop: '2px' }}>
+            Key at: {project.keyLinks[selectedCell] || 'unlinked'}
+          </div>
+        </div>
+      )}
+
+      {/* Spawn points from config */}
+      {config && config.spawnPoints.length > 0 && (
+        <div style={sectionStyle}>
+          <div style={labelStyle}>Spawn Points</div>
+          {config.spawnPoints.map((sp, i) => (
+            <div key={i} style={{ fontSize: '11px', color: '#88ff88', fontFamily: 'monospace', marginBottom: '2px' }}>
+              {sp.label}: [{sp.position.map(v => v.toFixed(0)).join(', ')}]
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Notes */}
+      {cell.notes && (
+        <div style={sectionStyle}>
+          <div style={labelStyle}>Notes</div>
+          <div style={{ fontSize: '12px', color: '#aaa', fontStyle: 'italic' }}>
+            {cell.notes}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = {
+  fontSize: '11px',
+  color: '#888',
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+  marginBottom: '6px',
+};
+
+const sectionStyle: React.CSSProperties = {
+  marginBottom: '16px',
+};
+
+const btnStyle: React.CSSProperties = {
+  padding: '6px 12px',
+  border: 'none',
+  borderRadius: '4px',
+  color: '#fff',
+  fontSize: '11px',
+  cursor: 'pointer',
+};
+
+function badgeStyle(color: string): React.CSSProperties {
+  return {
+    padding: '2px 6px',
+    background: color + '33',
+    border: `1px solid ${color}`,
+    borderRadius: '3px',
+    fontSize: '9px',
+    fontWeight: 700,
+    color,
+  };
+}
+
+// ============================================================================
+// Main ContentTab
+// ============================================================================
+
+export default function ContentTab({ project, onUpdateProject }: ContentTabProps) {
+  const [selectedCell, setSelectedCell] = useState<string | null>(null);
+  const [placingKey, setPlacingKey] = useState(false);
+
+  const cell = selectedCell ? project.cells[selectedCell] : null;
+  const config = cell ? getStageConfig(cell.stageName) : null;
+  const hasKey = selectedCell ? Object.values(project.keyLinks).includes(selectedCell) : false;
+
+  const handlePlaceKey = useCallback((pos: [number, number, number]) => {
+    if (!selectedCell) return;
+    onUpdateProject(prev => ({
+      ...prev,
+      cells: {
+        ...prev.cells,
+        [selectedCell]: { ...prev.cells[selectedCell], keyPosition: pos },
+      },
+    }));
+    setPlacingKey(false);
+  }, [selectedCell, onUpdateProject]);
+
+  const handleClearKeyPosition = useCallback(() => {
+    if (!selectedCell) return;
+    onUpdateProject(prev => {
+      const updated = { ...prev.cells[selectedCell] };
+      delete updated.keyPosition;
+      return {
+        ...prev,
+        cells: { ...prev.cells, [selectedCell]: updated },
+      };
+    });
+  }, [selectedCell, onUpdateProject]);
+
+  const handleTogglePlaceKey = useCallback(() => {
+    setPlacingKey(p => !p);
+  }, []);
+
+  // Select first cell with a key if none selected
+  const handleCellSelect = useCallback((pos: string) => {
+    setSelectedCell(pos);
+    setPlacingKey(false);
+  }, []);
+
+  return (
+    <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+      {/* Left panel — Mini grid */}
+      <div style={{
+        width: '260px',
+        borderRight: '1px solid #333',
+        background: '#151525',
+        padding: '12px',
+        overflowY: 'auto',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '12px',
+      }}>
+        <div style={{ fontSize: '11px', color: '#888', textTransform: 'uppercase', letterSpacing: '0.5px' }}>
+          Select Cell
+        </div>
+        <MiniGrid
+          project={project}
+          selectedCell={selectedCell}
+          onCellSelect={handleCellSelect}
+        />
+        <div style={{ fontSize: '11px', color: '#666', lineHeight: 1.5 }}>
+          <div><span style={{ display: 'inline-block', width: 8, height: 8, background: '#ff66aa', borderRadius: '50%', marginRight: 4 }} />Key (no position)</div>
+          <div><span style={{ display: 'inline-block', width: 8, height: 8, background: '#88ff88', borderRadius: '50%', marginRight: 4 }} />Key (placed)</div>
+          <div><span style={{ display: 'inline-block', width: 8, height: 8, background: '#ff66ff', borderRadius: 1, marginRight: 4 }} />Key-Gate</div>
+        </div>
+      </div>
+
+      {/* Center — 3D preview */}
+      <div style={{ flex: 1, position: 'relative', background: '#1a1a2e' }}>
+        {cell ? (
+          <>
+            <Canvas
+              camera={{ position: [0, 40, 40], fov: 50 }}
+            >
+              <color attach="background" args={['#1a1a2e']} />
+              <ambientLight intensity={0.6} />
+              <directionalLight position={[10, 20, 10]} intensity={0.8} />
+
+              <Suspense fallback={null}>
+                <StageModel mapId={cell.stageName} />
+              </Suspense>
+
+              {/* Ground grid */}
+              <Grid
+                args={[100, 100]}
+                position={[0, 0.01, 0]}
+                cellSize={1}
+                cellThickness={0.5}
+                cellColor="#333"
+                sectionSize={10}
+                sectionThickness={1}
+                sectionColor="#555"
+                fadeDistance={100}
+                fadeStrength={1}
+              />
+
+              {/* Gate markers */}
+              {config?.gates.map((gate, i) => (
+                <GateMarker
+                  key={i}
+                  gate={gate}
+                  isLocked={cell.lockedGate === gate.edge}
+                />
+              ))}
+
+              {/* Spawn points */}
+              {config?.spawnPoints.map((sp, i) => (
+                <SpawnMarker
+                  key={i}
+                  position={sp.position}
+                  edge={config.gates[i]?.edge || 'north'}
+                />
+              ))}
+
+              {/* Key marker (if this cell has a key with authored position) */}
+              {hasKey && cell.keyPosition && !placingKey && (
+                <KeyMarker position={cell.keyPosition} />
+              )}
+
+              {/* Key placement mode */}
+              {placingKey && (
+                <>
+                  <KeyPlacementCursor />
+                  <GroundClickPlane onPlace={handlePlaceKey} />
+                </>
+              )}
+
+              <OrbitControls makeDefault />
+            </Canvas>
+
+            {/* Overlay info */}
+            <div style={{
+              position: 'absolute', top: 12, left: 12,
+              background: 'rgba(0,0,0,0.7)', padding: '8px 12px',
+              borderRadius: '6px', fontSize: '12px', color: '#fff',
+            }}>
+              {cell.stageName}
+              {(cell.rotation ?? 0) !== 0 && ` (rotated ${cell.rotation}deg)`}
+            </div>
+
+            {placingKey && (
+              <div style={{
+                position: 'absolute', bottom: 12, left: '50%', transform: 'translateX(-50%)',
+                background: '#ff66aa', padding: '8px 20px',
+                borderRadius: '20px', fontSize: '13px', color: '#fff', fontWeight: 600,
+                cursor: 'pointer',
+              }}
+              onClick={() => setPlacingKey(false)}
+              >
+                Click in 3D view to place key | ESC to cancel
+              </div>
+            )}
+          </>
+        ) : (
+          <div style={{
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            height: '100%', color: '#666', fontSize: '14px',
+            flexDirection: 'column', gap: '8px',
+          }}>
+            <div style={{ fontSize: '32px', opacity: 0.3 }}>3D</div>
+            <div>Select a cell to preview its stage</div>
+          </div>
+        )}
+      </div>
+
+      {/* Right panel — Inspector */}
+      <div style={{
+        width: '260px',
+        borderLeft: '1px solid #333',
+        background: '#151525',
+        overflowY: 'auto',
+      }}>
+        {selectedCell ? (
+          <CellContentInspector
+            project={project}
+            selectedCell={selectedCell}
+            placingKey={placingKey}
+            onTogglePlaceKey={handleTogglePlaceKey}
+            onClearKeyPosition={handleClearKeyPosition}
+            onSetKeyPosition={handlePlaceKey}
+          />
+        ) : (
+          <div style={{ padding: '1rem', color: '#888', fontSize: '13px' }}>
+            Select a cell from the grid to inspect and edit its content.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/quest-editor/tabs/ExportTab.tsx
+++ b/src/components/quest-editor/tabs/ExportTab.tsx
@@ -83,17 +83,10 @@ function projectToGodotQuest(project: QuestProject): object {
       }
     }
 
-    // Key gate direction: which gate is locked?
+    // Key gate direction: which specific gate is locked
     let keyGateDirection = '';
-    if (pos in project.keyLinks) {
-      const keyCell = project.keyLinks[pos];
-      // Find direction from gate cell to key cell
-      for (const [dir, neighbor] of Object.entries(connections)) {
-        // The locked direction is the one that needs the key to pass
-        // It's any connected direction (convention: first connection)
-      }
-      // Actually the key_gate_direction is the direction that is locked
-      // For simplicity, we leave it empty if not determinable
+    if (pos in project.keyLinks && cell.lockedGate) {
+      keyGateDirection = cell.lockedGate;
     }
 
     cells.push({
@@ -182,6 +175,7 @@ function godotQuestToProject(quest: any): QuestProject {
     cells[cell.pos] = {
       stageName: cell.stage_id,
       rotation: cell.rotation || undefined,
+      lockedGate: cell.key_gate_direction || undefined,
       role: cell.is_end ? 'boss' : cell.is_start ? 'transit' : 'guard',
       manual: true,
     };

--- a/src/components/quest-editor/tabs/ExportTab.tsx
+++ b/src/components/quest-editor/tabs/ExportTab.tsx
@@ -119,6 +119,7 @@ function projectToGodotQuest(project: QuestProject): object {
   return {
     id: project.id,
     name: project.name,
+    description: project.metadata?.description || '',
     area_id: AREA_KEY_TO_ID[project.areaKey] || project.areaKey,
     sections: [{
       type: 'grid',
@@ -212,7 +213,7 @@ function godotQuestToProject(quest: any): QuestProject {
     keyLinks,
     metadata: {
       questName: quest.name || '',
-      description: '',
+      description: quest.description || '',
       questType: 'exploration',
       difficulty: 'normal',
       recommendedLevel: 1,

--- a/src/components/quest-editor/tabs/ExportTab.tsx
+++ b/src/components/quest-editor/tabs/ExportTab.tsx
@@ -89,7 +89,7 @@ function projectToGodotQuest(project: QuestProject): object {
       keyGateDirection = cell.lockedGate;
     }
 
-    cells.push({
+    const cellData: Record<string, unknown> = {
       pos,
       stage_id: cell.stageName,
       rotation: cell.rotation ?? 0,
@@ -103,7 +103,14 @@ function projectToGodotQuest(project: QuestProject): object {
       key_gate_direction: keyGateDirection,
       warp_edge: warpEdge,
       path_order: pathOrder.get(pos) ?? -1,
-    });
+    };
+
+    // Include authored key position if set
+    if (cell.keyPosition) {
+      cellData.key_position = cell.keyPosition;
+    }
+
+    cells.push(cellData);
   }
 
   // Sort cells by path_order for readability
@@ -172,13 +179,18 @@ function godotQuestToProject(quest: any): QuestProject {
     const [r, c] = cell.pos.split(',').map(Number);
     maxRow = Math.max(maxRow, r);
     maxCol = Math.max(maxCol, c);
-    cells[cell.pos] = {
+    const editorCell: EditorGridCell = {
       stageName: cell.stage_id,
       rotation: cell.rotation || undefined,
       lockedGate: cell.key_gate_direction || undefined,
       role: cell.is_end ? 'boss' : cell.is_start ? 'transit' : 'guard',
       manual: true,
     };
+    // Round-trip authored key position
+    if (cell.key_position && Array.isArray(cell.key_position)) {
+      editorCell.keyPosition = cell.key_position as [number, number, number];
+    }
+    cells[cell.pos] = editorCell;
     if (cell.is_start) startPos = cell.pos;
     if (cell.is_end) endPos = cell.pos;
     if (cell.is_key_gate && cell.key_for_cell) {

--- a/src/components/quest-editor/tabs/ExportTab.tsx
+++ b/src/components/quest-editor/tabs/ExportTab.tsx
@@ -10,7 +10,7 @@
  */
 
 import { useState, useCallback, useMemo, useRef } from 'react';
-import type { QuestProject, ValidationIssue, Direction, EditorGridCell } from '../types';
+import type { QuestProject, ValidationIssue, Direction, EditorGridCell, CellObject } from '../types';
 import { EDITOR_AREAS } from '../types';
 import type { MissionLayout, GridCell, StageArea, MissionContent } from '../../../systems/stage/types';
 import { generateMissionContent } from '../../../systems/stage/content-generator';
@@ -110,6 +110,20 @@ function projectToGodotQuest(project: QuestProject): object {
       cellData.key_position = cell.keyPosition;
     }
 
+    // Include placed objects
+    if (cell.objects && cell.objects.length > 0) {
+      cellData.objects = cell.objects.map(obj => {
+        const exported: Record<string, unknown> = {
+          type: obj.type,
+          position: obj.position,
+        };
+        if (obj.rotation) exported.rotation = obj.rotation;
+        if (obj.enemy_id) exported.enemy_id = obj.enemy_id;
+        if (obj.link_id) exported.link_id = obj.link_id;
+        return exported;
+      });
+    }
+
     cells.push(cellData);
   }
 
@@ -190,6 +204,17 @@ function godotQuestToProject(quest: any): QuestProject {
     // Round-trip authored key position
     if (cell.key_position && Array.isArray(cell.key_position)) {
       editorCell.keyPosition = cell.key_position as [number, number, number];
+    }
+    // Round-trip placed objects
+    if (cell.objects && Array.isArray(cell.objects)) {
+      editorCell.objects = cell.objects.map((obj: any, idx: number) => ({
+        id: obj.id || `${obj.type}_${idx}`,
+        type: obj.type,
+        position: obj.position as [number, number, number],
+        rotation: obj.rotation,
+        enemy_id: obj.enemy_id,
+        link_id: obj.link_id,
+      } as CellObject));
     }
     cells[cell.pos] = editorCell;
     if (cell.is_start) startPos = cell.pos;

--- a/src/components/quest-editor/tabs/ExportTab.tsx
+++ b/src/components/quest-editor/tabs/ExportTab.tsx
@@ -1,0 +1,713 @@
+/**
+ * ExportTab — JSON export with validation
+ *
+ * Three formats:
+ * 1. Quest Layout JSON — the QuestProject data, re-importable
+ * 2. Godot Quest JSON — cell format matching grid_generator output
+ * 3. Mission Content JSON — calls content-generator for procedural content
+ *
+ * Plus: Import Godot Quest JSON back into a QuestProject for editing.
+ */
+
+import { useState, useCallback, useMemo, useRef } from 'react';
+import type { QuestProject, ValidationIssue, Direction, EditorGridCell } from '../types';
+import { EDITOR_AREAS } from '../types';
+import type { MissionLayout, GridCell, StageArea, MissionContent } from '../../../systems/stage/types';
+import { generateMissionContent } from '../../../systems/stage/content-generator';
+import {
+  getOriginalGates,
+  getRotatedGates,
+  getNeighbor,
+  isValidPos,
+  oppositeDirection,
+  getStageConfig,
+  getStageSuffix,
+} from '../hooks/useStageConfigs';
+
+interface ExportTabProps {
+  project: QuestProject;
+  setProject?: (project: QuestProject) => void;
+}
+
+// ============================================================================
+// Area mapping: editor areaKey ↔ Godot area_id
+// ============================================================================
+
+const AREA_KEY_TO_ID: Record<string, string> = {
+  valley: 'gurhacia',
+  wetlands: 'ozette',
+  snowfield: 'rioh',
+  makara: 'makara',
+  paru: 'paru',
+  arca: 'arca',
+  shrine: 'dark',
+  tower: 'tower',
+};
+
+const AREA_ID_TO_KEY: Record<string, string> = Object.fromEntries(
+  Object.entries(AREA_KEY_TO_ID).map(([k, v]) => [v, k])
+);
+
+// ============================================================================
+// Export: QuestProject → Godot Quest JSON
+// ============================================================================
+
+function projectToGodotQuest(project: QuestProject): object {
+  const cells: object[] = [];
+  // Build path_order from BFS starting at startPos
+  const pathOrder = buildPathOrder(project);
+
+  for (const [pos, cell] of Object.entries(project.cells)) {
+    const [row, col] = pos.split(',').map(Number);
+    const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+
+    // Build connections
+    const connections: Record<string, string> = {};
+    for (const worldDir of gates) {
+      const [nr, nc] = getNeighbor(row, col, worldDir);
+      const nk = `${nr},${nc}`;
+      if (project.cells[nk]) {
+        connections[worldDir] = nk;
+      }
+    }
+
+    // Find warp edge for end cell
+    let warpEdge = '';
+    if (project.endPos === pos) {
+      for (const worldDir of gates) {
+        const [nr, nc] = getNeighbor(row, col, worldDir);
+        if (!isValidPos(nr, nc, project.gridSize) || !project.cells[`${nr},${nc}`]) {
+          warpEdge = worldDir;
+          break;
+        }
+      }
+    }
+
+    // Key gate direction: which gate is locked?
+    let keyGateDirection = '';
+    if (pos in project.keyLinks) {
+      const keyCell = project.keyLinks[pos];
+      // Find direction from gate cell to key cell
+      for (const [dir, neighbor] of Object.entries(connections)) {
+        // The locked direction is the one that needs the key to pass
+        // It's any connected direction (convention: first connection)
+      }
+      // Actually the key_gate_direction is the direction that is locked
+      // For simplicity, we leave it empty if not determinable
+    }
+
+    cells.push({
+      pos,
+      stage_id: cell.stageName,
+      rotation: cell.rotation ?? 0,
+      connections,
+      is_start: project.startPos === pos,
+      is_end: project.endPos === pos,
+      is_branch: Object.keys(connections).length > 2,
+      has_key: Object.values(project.keyLinks).includes(pos),
+      key_for_cell: Object.entries(project.keyLinks).find(([_, v]) => v === pos)?.[0] || '',
+      is_key_gate: pos in project.keyLinks,
+      key_gate_direction: keyGateDirection,
+      warp_edge: warpEdge,
+      path_order: pathOrder.get(pos) ?? -1,
+    });
+  }
+
+  // Sort cells by path_order for readability
+  cells.sort((a: any, b: any) => (a.path_order ?? 999) - (b.path_order ?? 999));
+
+  return {
+    id: project.id,
+    name: project.name,
+    area_id: AREA_KEY_TO_ID[project.areaKey] || project.areaKey,
+    sections: [{
+      type: 'grid',
+      area: project.variant,
+      start_pos: project.startPos || '',
+      end_pos: project.endPos || '',
+      cells,
+    }],
+  };
+}
+
+/** BFS from startPos to assign path_order */
+function buildPathOrder(project: QuestProject): Map<string, number> {
+  const order = new Map<string, number>();
+  if (!project.startPos || !project.cells[project.startPos]) return order;
+
+  const visited = new Set<string>();
+  const queue: string[] = [project.startPos];
+  visited.add(project.startPos);
+  let idx = 0;
+
+  while (queue.length > 0) {
+    const pos = queue.shift()!;
+    order.set(pos, idx++);
+
+    const cell = project.cells[pos];
+    if (!cell) continue;
+
+    const [row, col] = pos.split(',').map(Number);
+    const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+
+    for (const dir of gates) {
+      const [nr, nc] = getNeighbor(row, col, dir);
+      const nk = `${nr},${nc}`;
+      if (!visited.has(nk) && project.cells[nk]) {
+        visited.add(nk);
+        queue.push(nk);
+      }
+    }
+  }
+
+  return order;
+}
+
+// ============================================================================
+// Import: Godot Quest JSON → QuestProject
+// ============================================================================
+
+function godotQuestToProject(quest: any): QuestProject {
+  const section = quest.sections?.[0] || {};
+  const cells: Record<string, EditorGridCell> = {};
+  let startPos: string | null = null;
+  let endPos: string | null = null;
+  const keyLinks: Record<string, string> = {};
+  let maxRow = 0, maxCol = 0;
+
+  for (const cell of section.cells || []) {
+    const [r, c] = cell.pos.split(',').map(Number);
+    maxRow = Math.max(maxRow, r);
+    maxCol = Math.max(maxCol, c);
+    cells[cell.pos] = {
+      stageName: cell.stage_id,
+      rotation: cell.rotation || undefined,
+      role: cell.is_end ? 'boss' : cell.is_start ? 'transit' : 'guard',
+      manual: true,
+    };
+    if (cell.is_start) startPos = cell.pos;
+    if (cell.is_end) endPos = cell.pos;
+    if (cell.is_key_gate && cell.key_for_cell) {
+      keyLinks[cell.pos] = cell.key_for_cell;
+    }
+  }
+
+  const areaKey = AREA_ID_TO_KEY[quest.area_id] || 'valley';
+
+  return {
+    id: quest.id || crypto.randomUUID(),
+    name: quest.name || 'Imported Quest',
+    areaKey,
+    variant: section.area || 'a',
+    gridSize: Math.max(3, Math.max(maxRow, maxCol) + 1),
+    cells,
+    startPos,
+    endPos,
+    keyLinks,
+    metadata: {
+      questName: quest.name || '',
+      description: '',
+      questType: 'exploration',
+      difficulty: 'normal',
+      recommendedLevel: 1,
+    },
+    cellContents: {},
+    lastModified: new Date().toISOString(),
+    version: 1,
+  };
+}
+
+// ============================================================================
+// MissionLayout export (existing)
+// ============================================================================
+
+/** Convert editor project to MissionLayout for content generator */
+function projectToMissionLayout(project: QuestProject): MissionLayout | null {
+  const cells: GridCell[] = [];
+  const stageConfigs: Record<string, any> = {};
+
+  for (const [pos, cell] of Object.entries(project.cells)) {
+    const [row, col] = pos.split(',').map(Number);
+    const rotatedGates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+    const suffix = getStageSuffix(cell.stageName);
+
+    // Build connections map: gate → neighbor pos
+    const connections: Record<string, string> = {};
+    for (const gate of rotatedGates) {
+      const [nr, nc] = getNeighbor(row, col, gate);
+      const neighborKey = `${nr},${nc}`;
+      if (project.cells[neighborKey]) {
+        connections[gate] = neighborKey;
+      }
+    }
+
+    // Find warp gate (end cell gate pointing outside grid)
+    let warpGate: string | undefined;
+    if (project.endPos === pos) {
+      for (const gate of rotatedGates) {
+        const [nr, nc] = getNeighbor(row, col, gate);
+        if (!isValidPos(nr, nc, project.gridSize)) {
+          warpGate = gate;
+          break;
+        }
+      }
+    }
+
+    const gridCell: GridCell = {
+      pos,
+      stage: suffix,
+      fullStageName: cell.stageName,
+      connections,
+    };
+
+    if (project.startPos === pos) gridCell.start = true;
+    if (project.endPos === pos) gridCell.end = true;
+    if (pos in project.keyLinks) gridCell.keyGate = 'locked';
+    if (Object.values(project.keyLinks).includes(pos)) gridCell.key = true;
+    if (warpGate) gridCell.warp = warpGate;
+
+    cells.push(gridCell);
+
+    // Collect stage config
+    const config = getStageConfig(cell.stageName);
+    if (config) {
+      stageConfigs[cell.stageName] = config;
+    }
+  }
+
+  const areaVariant = `${project.areaKey}-${project.variant}`;
+  // Map to StageArea type
+  const stageAreaMap: Record<string, StageArea> = {
+    'valley-a': 'valley-a',
+    'valley-b': 'valley-b',
+    'wetlands-a': 'wetland-a',
+    'wetlands-b': 'wetland-b',
+    'snowfield-a': 'snowfield-a',
+    'snowfield-b': 'snowfield-b',
+    'makara-a': 'ruins-a',
+    'makara-b': 'ruins-b',
+    'paru-a': 'city-a',
+    'paru-b': 'city-b',
+  };
+
+  return {
+    area: stageAreaMap[areaVariant] || ('valley-a' as StageArea),
+    cells,
+    stageConfigs,
+  };
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+/** Validate for export */
+function validateForExport(project: QuestProject): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  if (!project.startPos) issues.push({ severity: 'error', message: 'No start cell' });
+  if (!project.endPos) issues.push({ severity: 'error', message: 'No end cell' });
+  if (Object.keys(project.cells).length === 0) issues.push({ severity: 'error', message: 'No cells' });
+
+  // Check orphan gates
+  for (const [pos, cell] of Object.entries(project.cells)) {
+    const [row, col] = pos.split(',').map(Number);
+    const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+
+    for (const dir of gates) {
+      const [nr, nc] = getNeighbor(row, col, dir);
+      if (!isValidPos(nr, nc, project.gridSize)) continue;
+
+      const neighborKey = `${nr},${nc}`;
+      const neighbor = project.cells[neighborKey];
+
+      if (neighbor) {
+        const neighborGates = getRotatedGates(neighbor.stageName, neighbor.rotation ?? 0);
+        if (!neighborGates.has(oppositeDirection(dir))) {
+          issues.push({
+            severity: 'error',
+            message: `Orphan gate: ${pos} (${dir}) → ${neighborKey}`,
+            cellPos: pos,
+          });
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export default function ExportTab({ project, setProject }: ExportTabProps) {
+  const [copyStatus, setCopyStatus] = useState('');
+  const [missionResult, setMissionResult] = useState<string>('');
+  const [importText, setImportText] = useState('');
+  const [importError, setImportError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const issues = useMemo(() => validateForExport(project), [project]);
+  const hasErrors = issues.some(i => i.severity === 'error');
+
+  const layoutJson = useMemo(() => JSON.stringify(project, null, 2), [project]);
+  const godotJson = useMemo(() => {
+    if (hasErrors) return '';
+    return JSON.stringify(projectToGodotQuest(project), null, 2);
+  }, [project, hasErrors]);
+
+  const copyToClipboard = useCallback(async (text: string, label: string) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopyStatus(`${label} copied!`);
+      setTimeout(() => setCopyStatus(''), 2000);
+    } catch {
+      setCopyStatus('Copy failed');
+      setTimeout(() => setCopyStatus(''), 2000);
+    }
+  }, []);
+
+  const downloadJson = useCallback((text: string, filename: string) => {
+    const blob = new Blob([text], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }, []);
+
+  const generateMission = useCallback(() => {
+    const layout = projectToMissionLayout(project);
+    if (!layout) {
+      setMissionResult('Failed to build layout');
+      return;
+    }
+
+    try {
+      const result = generateMissionContent(layout, {
+        enemyArea: 'gurhacia',
+        difficulty: project.metadata.difficulty || 'normal',
+        playerLevel: project.metadata.recommendedLevel || 1,
+        seed: Date.now(),
+        includeBoss: !!project.endPos,
+      });
+
+      const json = JSON.stringify(result.mission, null, 2);
+      setMissionResult(json);
+    } catch (e) {
+      setMissionResult(`Generation error: ${e}`);
+    }
+  }, [project]);
+
+  const handleImport = useCallback((jsonText: string) => {
+    setImportError('');
+    try {
+      const parsed = JSON.parse(jsonText);
+
+      // Detect format: Godot quest has "sections", QuestProject has "cells"
+      if (parsed.sections && Array.isArray(parsed.sections)) {
+        // Godot quest JSON → convert to QuestProject
+        const imported = godotQuestToProject(parsed);
+        if (setProject) {
+          setProject(imported);
+          setCopyStatus('Imported Godot quest!');
+          setTimeout(() => setCopyStatus(''), 2000);
+          setImportText('');
+        } else {
+          setImportError('Import not available (setProject not provided)');
+        }
+      } else if (parsed.cells && parsed.areaKey) {
+        // Already a QuestProject
+        if (setProject) {
+          setProject(parsed as QuestProject);
+          setCopyStatus('Imported quest project!');
+          setTimeout(() => setCopyStatus(''), 2000);
+          setImportText('');
+        } else {
+          setImportError('Import not available (setProject not provided)');
+        }
+      } else {
+        setImportError('Unrecognized JSON format. Expected Godot quest (with "sections") or QuestProject (with "cells").');
+      }
+    } catch (e) {
+      setImportError(`Parse error: ${e}`);
+    }
+  }, [setProject]);
+
+  const handleFileImport = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        handleImport(reader.result);
+      }
+    };
+    reader.readAsText(file);
+    // Reset so same file can be re-selected
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }, [handleImport]);
+
+  const buttonStyle = {
+    padding: '8px 16px', background: '#555588', border: 'none',
+    borderRadius: '6px', color: '#fff', fontSize: '12px', cursor: 'pointer',
+  };
+
+  return (
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      overflow: 'auto', padding: '24px', gap: '24px',
+    }}>
+      {/* Import Quest JSON */}
+      {setProject && (
+        <div>
+          <div style={{
+            fontSize: '14px', fontWeight: 600, color: '#fff', marginBottom: '8px',
+            display: 'flex', alignItems: 'center', gap: '8px',
+          }}>
+            Import Quest JSON
+            <span style={{ fontSize: '11px', color: '#888', fontWeight: 400 }}>
+              (Godot quest or QuestProject format)
+            </span>
+          </div>
+          <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+            <button
+              onClick={() => handleImport(importText)}
+              disabled={!importText.trim()}
+              style={{
+                ...buttonStyle,
+                background: !importText.trim() ? '#444' : '#448844',
+                cursor: !importText.trim() ? 'not-allowed' : 'pointer',
+              }}
+            >
+              Import from Text
+            </button>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".json"
+              onChange={handleFileImport}
+              style={{ display: 'none' }}
+            />
+            <button
+              onClick={() => fileInputRef.current?.click()}
+              style={buttonStyle}
+            >
+              Import from File
+            </button>
+          </div>
+          <textarea
+            value={importText}
+            onChange={(e) => setImportText(e.target.value)}
+            placeholder="Paste Godot quest JSON or QuestProject JSON here..."
+            style={{
+              width: '100%',
+              height: '80px',
+              background: '#111',
+              border: '1px solid #333',
+              borderRadius: '6px',
+              padding: '8px',
+              fontSize: '11px',
+              color: '#aaa',
+              fontFamily: 'monospace',
+              resize: 'vertical',
+            }}
+          />
+          {importError && (
+            <div style={{ color: '#ff8888', fontSize: '12px', marginTop: '4px' }}>
+              {importError}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Validation */}
+      <div>
+        <div style={{
+          fontSize: '14px', fontWeight: 600, color: '#fff', marginBottom: '8px',
+        }}>
+          Validation
+        </div>
+        {issues.length === 0 ? (
+          <div style={{ color: '#88ff88', fontSize: '13px' }}>
+            No issues found — ready to export
+          </div>
+        ) : (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            {issues.map((issue, i) => (
+              <div key={i} style={{
+                padding: '4px 8px',
+                fontSize: '12px',
+                color: issue.severity === 'error' ? '#ff8888' :
+                       issue.severity === 'warning' ? '#ffcc66' : '#8888ff',
+              }}>
+                {issue.severity === 'error' ? '[ERROR]' : issue.severity === 'warning' ? '[WARN]' : '[INFO]'} {issue.message}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Status */}
+      {copyStatus && (
+        <div style={{ color: '#88ff88', fontSize: '13px', textAlign: 'center' }}>
+          {copyStatus}
+        </div>
+      )}
+
+      {/* Godot Quest JSON */}
+      <div>
+        <div style={{
+          fontSize: '14px', fontWeight: 600, color: '#fff', marginBottom: '8px',
+          display: 'flex', alignItems: 'center', gap: '8px',
+        }}>
+          Godot Quest JSON
+          <span style={{ fontSize: '11px', color: '#888', fontWeight: 400 }}>
+            (copy to psz-godot/data/quests/)
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+          <button
+            onClick={() => copyToClipboard(godotJson, 'Godot quest')}
+            disabled={hasErrors}
+            style={{
+              ...buttonStyle,
+              background: hasErrors ? '#444' : '#448844',
+              cursor: hasErrors ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Copy to Clipboard
+          </button>
+          <button
+            onClick={() => {
+              const id = (project.name || 'quest').toLowerCase().replace(/\s+/g, '_').replace(/[^a-z0-9_]/g, '');
+              downloadJson(godotJson, `${id}.json`);
+            }}
+            disabled={hasErrors}
+            style={{
+              ...buttonStyle,
+              background: hasErrors ? '#444' : buttonStyle.background,
+              cursor: hasErrors ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Download
+          </button>
+        </div>
+        {!hasErrors && godotJson && (
+          <pre style={{
+            background: '#111',
+            border: '1px solid #333',
+            borderRadius: '6px',
+            padding: '12px',
+            fontSize: '10px',
+            color: '#aaa',
+            maxHeight: '300px',
+            overflow: 'auto',
+            fontFamily: 'monospace',
+          }}>
+            {godotJson}
+          </pre>
+        )}
+      </div>
+
+      {/* Quest Layout JSON */}
+      <div>
+        <div style={{
+          fontSize: '14px', fontWeight: 600, color: '#fff', marginBottom: '8px',
+          display: 'flex', alignItems: 'center', gap: '8px',
+        }}>
+          Quest Layout JSON
+          <span style={{ fontSize: '11px', color: '#888', fontWeight: 400 }}>
+            (re-importable by editor)
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+          <button
+            onClick={() => copyToClipboard(layoutJson, 'Layout')}
+            style={buttonStyle}
+          >
+            Copy to Clipboard
+          </button>
+          <button
+            onClick={() => downloadJson(layoutJson, `quest-${project.name.toLowerCase().replace(/\s+/g, '-')}.json`)}
+            style={buttonStyle}
+          >
+            Download
+          </button>
+        </div>
+        <pre style={{
+          background: '#111',
+          border: '1px solid #333',
+          borderRadius: '6px',
+          padding: '12px',
+          fontSize: '10px',
+          color: '#aaa',
+          maxHeight: '300px',
+          overflow: 'auto',
+          fontFamily: 'monospace',
+        }}>
+          {layoutJson}
+        </pre>
+      </div>
+
+      {/* Mission Content JSON */}
+      <div>
+        <div style={{
+          fontSize: '14px', fontWeight: 600, color: '#fff', marginBottom: '8px',
+          display: 'flex', alignItems: 'center', gap: '8px',
+        }}>
+          Mission Content JSON
+          <span style={{ fontSize: '11px', color: '#888', fontWeight: 400 }}>
+            (procedurally generated for Godot)
+          </span>
+        </div>
+        <div style={{ display: 'flex', gap: '8px', marginBottom: '8px' }}>
+          <button
+            onClick={generateMission}
+            disabled={hasErrors}
+            style={{
+              ...buttonStyle,
+              background: hasErrors ? '#444' : '#448844',
+              cursor: hasErrors ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Generate Mission Content
+          </button>
+          {missionResult && !missionResult.startsWith('Failed') && !missionResult.startsWith('Generation error') && (
+            <>
+              <button
+                onClick={() => copyToClipboard(missionResult, 'Mission')}
+                style={buttonStyle}
+              >
+                Copy
+              </button>
+              <button
+                onClick={() => downloadJson(missionResult, `mission-${project.name.toLowerCase().replace(/\s+/g, '-')}.json`)}
+                style={buttonStyle}
+              >
+                Download
+              </button>
+            </>
+          )}
+        </div>
+        {missionResult && (
+          <pre style={{
+            background: '#111',
+            border: `1px solid ${missionResult.startsWith('Failed') || missionResult.startsWith('Generation error') ? '#884444' : '#333'}`,
+            borderRadius: '6px',
+            padding: '12px',
+            fontSize: '10px',
+            color: missionResult.startsWith('Failed') || missionResult.startsWith('Generation error') ? '#ff8888' : '#aaa',
+            maxHeight: '400px',
+            overflow: 'auto',
+            fontFamily: 'monospace',
+          }}>
+            {missionResult}
+          </pre>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/quest-editor/tabs/LayoutTab.tsx
+++ b/src/components/quest-editor/tabs/LayoutTab.tsx
@@ -3,7 +3,7 @@
  */
 
 import { useState, useCallback } from 'react';
-import type { QuestProject, EditorGridCell, ValidationIssue } from '../types';
+import type { QuestProject, EditorGridCell, ValidationIssue, Direction } from '../types';
 import { generateGrid, type GenParams } from '../shared/grid-generation';
 import GridCanvas from '../shared/GridCanvas';
 import CellInspector from '../shared/CellInspector';
@@ -157,7 +157,7 @@ export default function LayoutTab({ project, onUpdateProject }: LayoutTabProps) 
     }));
   }, [onUpdateProject]);
 
-  // Toggle key on cell
+  // Toggle key on cell — links this cell as key holder for an unlinked gate
   const handleToggleKey = useCallback((pos: string) => {
     onUpdateProject(prev => {
       const newLinks = { ...prev.keyLinks };
@@ -168,8 +168,13 @@ export default function LayoutTab({ project, onUpdateProject }: LayoutTabProps) 
           return { ...prev, keyLinks: newLinks };
         }
       }
-      // Otherwise, mark as key — user will need to link to a gate
-      // For now, just add an unlinked key placeholder
+      // Find first unlinked key-gate and assign this cell as its key
+      for (const [gate, key] of Object.entries(newLinks)) {
+        if (!key) {
+          newLinks[gate] = pos;
+          return { ...prev, keyLinks: newLinks };
+        }
+      }
       return prev;
     });
   }, [onUpdateProject]);
@@ -179,14 +184,29 @@ export default function LayoutTab({ project, onUpdateProject }: LayoutTabProps) 
     onUpdateProject(prev => {
       const newLinks = { ...prev.keyLinks };
       if (pos in newLinks) {
+        // Remove key-gate and clear lockedGate
         delete newLinks[pos];
+        const newCells = { ...prev.cells };
+        if (newCells[pos]) {
+          newCells[pos] = { ...newCells[pos], lockedGate: undefined };
+        }
+        return { ...prev, cells: newCells, keyLinks: newLinks };
       } else {
-        // Create key-gate with no key assigned yet
-        // Will need the user to click a cell to assign the key
         newLinks[pos] = '';
       }
       return { ...prev, keyLinks: newLinks };
     });
+  }, [onUpdateProject]);
+
+  // Set which gate direction is locked on a key-gate cell
+  const handleSetLockedGate = useCallback((pos: string, dir: Direction | undefined) => {
+    onUpdateProject(prev => ({
+      ...prev,
+      cells: {
+        ...prev.cells,
+        [pos]: { ...prev.cells[pos], lockedGate: dir },
+      },
+    }));
   }, [onUpdateProject]);
 
   // Clear a cell
@@ -376,6 +396,7 @@ export default function LayoutTab({ project, onUpdateProject }: LayoutTabProps) 
             onSetEnd={handleSetEnd}
             onToggleKey={handleToggleKey}
             onToggleKeyGate={handleToggleKeyGate}
+            onSetLockedGate={handleSetLockedGate}
             onClearCell={handleClearCell}
             onChangeStage={handleChangeStage}
           />

--- a/src/components/quest-editor/tabs/LayoutTab.tsx
+++ b/src/components/quest-editor/tabs/LayoutTab.tsx
@@ -1,0 +1,493 @@
+/**
+ * LayoutTab — Grid layout editing with toolbar, canvas, and inspector
+ */
+
+import { useState, useCallback } from 'react';
+import type { QuestProject, EditorGridCell, ValidationIssue } from '../types';
+import { generateGrid, type GenParams } from '../shared/grid-generation';
+import GridCanvas from '../shared/GridCanvas';
+import CellInspector from '../shared/CellInspector';
+import StagePicker from '../shared/StagePicker';
+import { getRotatedGates, getNeighbor, isValidPos, oppositeDirection } from '../hooks/useStageConfigs';
+
+interface LayoutTabProps {
+  project: QuestProject;
+  onUpdateProject: (updater: (prev: QuestProject) => QuestProject) => void;
+}
+
+/** Validate the current layout and return issues */
+function validateLayout(project: QuestProject): ValidationIssue[] {
+  const issues: ValidationIssue[] = [];
+
+  // Check for start/end
+  if (!project.startPos) {
+    issues.push({ severity: 'error', message: 'No start cell designated' });
+  }
+  if (!project.endPos) {
+    issues.push({ severity: 'error', message: 'No end cell designated' });
+  }
+
+  // Check cell count
+  const cellCount = Object.keys(project.cells).length;
+  if (cellCount === 0) {
+    issues.push({ severity: 'error', message: 'Grid is empty — no cells placed' });
+    return issues;
+  }
+
+  // Check gate connections
+  for (const [pos, cell] of Object.entries(project.cells)) {
+    const [row, col] = pos.split(',').map(Number);
+    const gates = getRotatedGates(cell.stageName, cell.rotation ?? 0);
+
+    for (const dir of gates) {
+      const [nr, nc] = getNeighbor(row, col, dir);
+
+      if (!isValidPos(nr, nc, project.gridSize)) {
+        // Gate to outside grid — warp candidate (info)
+        issues.push({
+          severity: 'info',
+          message: `Gate at ${pos} points outside grid (${dir}) — warp candidate`,
+          cellPos: pos,
+        });
+        continue;
+      }
+
+      const neighborKey = `${nr},${nc}`;
+      const neighbor = project.cells[neighborKey];
+
+      if (!neighbor) {
+        // Gate to empty cell
+        issues.push({
+          severity: 'warning',
+          message: `Gate at ${pos} (${dir}) leads to empty cell ${neighborKey}`,
+          cellPos: pos,
+        });
+      } else {
+        // Check for matching return gate
+        const neighborGates = getRotatedGates(neighbor.stageName, neighbor.rotation ?? 0);
+        if (!neighborGates.has(oppositeDirection(dir))) {
+          issues.push({
+            severity: 'error',
+            message: `Orphan gate at ${pos} (${dir}) — neighbor ${neighborKey} has no return gate`,
+            cellPos: pos,
+          });
+        }
+      }
+    }
+  }
+
+  // Check key-gate links
+  for (const [gatePos, keyPos] of Object.entries(project.keyLinks)) {
+    if (!project.cells[gatePos]) {
+      issues.push({ severity: 'error', message: `Key-gate at ${gatePos} has no cell`, cellPos: gatePos });
+    }
+    if (!project.cells[keyPos]) {
+      issues.push({ severity: 'error', message: `Key for gate ${gatePos} at ${keyPos} has no cell`, cellPos: keyPos });
+    }
+  }
+
+  return issues;
+}
+
+export default function LayoutTab({ project, onUpdateProject }: LayoutTabProps) {
+  const [selectedCell, setSelectedCell] = useState<string | null>(null);
+  const [pickerTarget, setPickerTarget] = useState<string | null>(null);
+  const [showGenDialog, setShowGenDialog] = useState(false);
+  const [validationIssues, setValidationIssues] = useState<ValidationIssue[]>([]);
+  const [genParams, setGenParams] = useState<GenParams>({
+    gridSize: project.gridSize,
+    usedCells: 8,
+    keyGates: 1,
+    branches: 2,
+  });
+
+  // Handle clicking an empty cell — open StagePicker
+  const handleEmptyCellClick = useCallback((pos: string) => {
+    setPickerTarget(pos);
+    setSelectedCell(pos);
+  }, []);
+
+  // Handle clicking an occupied cell — select for inspector
+  const handleCellSelect = useCallback((pos: string) => {
+    setSelectedCell(pos);
+  }, []);
+
+  // Place a stage in a cell
+  const handlePlaceStage = useCallback((stageName: string, rotation: number) => {
+    if (!pickerTarget) return;
+    onUpdateProject(prev => ({
+      ...prev,
+      cells: {
+        ...prev.cells,
+        [pickerTarget]: {
+          stageName,
+          rotation: rotation || undefined,
+          role: 'transit',
+          manual: true,
+        },
+      },
+    }));
+    setPickerTarget(null);
+  }, [pickerTarget, onUpdateProject]);
+
+  // Update a cell's properties
+  const handleUpdateCell = useCallback((pos: string, updates: Partial<EditorGridCell>) => {
+    onUpdateProject(prev => ({
+      ...prev,
+      cells: {
+        ...prev.cells,
+        [pos]: { ...prev.cells[pos], ...updates, manual: true },
+      },
+    }));
+  }, [onUpdateProject]);
+
+  // Set start cell
+  const handleSetStart = useCallback((pos: string) => {
+    onUpdateProject(prev => ({
+      ...prev,
+      startPos: prev.startPos === pos ? null : pos,
+    }));
+  }, [onUpdateProject]);
+
+  // Set end cell
+  const handleSetEnd = useCallback((pos: string) => {
+    onUpdateProject(prev => ({
+      ...prev,
+      endPos: prev.endPos === pos ? null : pos,
+    }));
+  }, [onUpdateProject]);
+
+  // Toggle key on cell
+  const handleToggleKey = useCallback((pos: string) => {
+    onUpdateProject(prev => {
+      const newLinks = { ...prev.keyLinks };
+      // If this cell is already a key location, remove the link
+      for (const [gate, key] of Object.entries(newLinks)) {
+        if (key === pos) {
+          delete newLinks[gate];
+          return { ...prev, keyLinks: newLinks };
+        }
+      }
+      // Otherwise, mark as key — user will need to link to a gate
+      // For now, just add an unlinked key placeholder
+      return prev;
+    });
+  }, [onUpdateProject]);
+
+  // Toggle key-gate on cell
+  const handleToggleKeyGate = useCallback((pos: string) => {
+    onUpdateProject(prev => {
+      const newLinks = { ...prev.keyLinks };
+      if (pos in newLinks) {
+        delete newLinks[pos];
+      } else {
+        // Create key-gate with no key assigned yet
+        // Will need the user to click a cell to assign the key
+        newLinks[pos] = '';
+      }
+      return { ...prev, keyLinks: newLinks };
+    });
+  }, [onUpdateProject]);
+
+  // Clear a cell
+  const handleClearCell = useCallback((pos: string) => {
+    onUpdateProject(prev => {
+      const newCells = { ...prev.cells };
+      delete newCells[pos];
+      const newLinks = { ...prev.keyLinks };
+      delete newLinks[pos];
+      // Also remove any key links pointing to this cell
+      for (const [gate, key] of Object.entries(newLinks)) {
+        if (key === pos) delete newLinks[gate];
+      }
+      return {
+        ...prev,
+        cells: newCells,
+        keyLinks: newLinks,
+        startPos: prev.startPos === pos ? null : prev.startPos,
+        endPos: prev.endPos === pos ? null : prev.endPos,
+      };
+    });
+    setSelectedCell(null);
+  }, [onUpdateProject]);
+
+  // Change stage (reopen picker for occupied cell)
+  const handleChangeStage = useCallback((pos: string) => {
+    setPickerTarget(pos);
+  }, []);
+
+  // Generate grid
+  const handleGenerate = useCallback(() => {
+    const result = generateGrid(project.areaKey, project.variant, {
+      ...genParams,
+      gridSize: project.gridSize,
+    });
+
+    if (Object.keys(result.cells).length === 0) {
+      alert('Generation failed — try different parameters or a larger grid.');
+      return;
+    }
+
+    onUpdateProject(prev => ({
+      ...prev,
+      cells: result.cells,
+      startPos: result.startPos,
+      endPos: result.endPos,
+      keyLinks: result.keyLinks,
+    }));
+
+    setShowGenDialog(false);
+    setSelectedCell(null);
+  }, [project.areaKey, project.variant, project.gridSize, genParams, onUpdateProject]);
+
+  // Clear all cells
+  const handleClear = useCallback(() => {
+    if (!confirm('Clear all cells? This cannot be undone (but you can use Ctrl+Z).')) return;
+    onUpdateProject(prev => ({
+      ...prev,
+      cells: {},
+      startPos: null,
+      endPos: null,
+      keyLinks: {},
+    }));
+    setSelectedCell(null);
+  }, [onUpdateProject]);
+
+  // Validate
+  const handleValidate = useCallback(() => {
+    setValidationIssues(validateLayout(project));
+  }, [project]);
+
+  const cellCount = Object.keys(project.cells).length;
+
+  return (
+    <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+      {/* Main content */}
+      <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'auto' }}>
+        {/* Toolbar */}
+        <div style={{
+          display: 'flex',
+          gap: '8px',
+          padding: '12px 16px',
+          borderBottom: '1px solid #333',
+          background: '#151525',
+          alignItems: 'center',
+          flexWrap: 'wrap',
+        }}>
+          <button
+            onClick={() => setShowGenDialog(true)}
+            style={{
+              padding: '8px 16px', background: '#5588ff', border: 'none',
+              borderRadius: '6px', color: '#fff', fontSize: '13px',
+              fontWeight: 600, cursor: 'pointer',
+            }}
+          >
+            Generate
+          </button>
+          <button
+            onClick={handleClear}
+            style={{
+              padding: '8px 16px', background: '#884444', border: 'none',
+              borderRadius: '6px', color: '#fff', fontSize: '13px', cursor: 'pointer',
+            }}
+          >
+            Clear
+          </button>
+          <button
+            onClick={handleValidate}
+            style={{
+              padding: '8px 16px', background: '#448844', border: 'none',
+              borderRadius: '6px', color: '#fff', fontSize: '13px', cursor: 'pointer',
+            }}
+          >
+            Validate
+          </button>
+          <div style={{ flex: 1 }} />
+          <span style={{ fontSize: '12px', color: '#888' }}>
+            {cellCount} cells | {project.gridSize}x{project.gridSize}
+          </span>
+        </div>
+
+        {/* Grid */}
+        <div style={{
+          flex: 1,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          padding: '24px',
+          overflow: 'auto',
+        }}>
+          <GridCanvas
+            project={project}
+            selectedCell={selectedCell}
+            onCellClick={handleEmptyCellClick}
+            onCellSelect={handleCellSelect}
+          />
+        </div>
+
+        {/* Validation issues */}
+        {validationIssues.length > 0 && (
+          <div style={{
+            padding: '12px 16px',
+            borderTop: '1px solid #333',
+            background: '#151525',
+            maxHeight: '200px',
+            overflowY: 'auto',
+          }}>
+            <div style={{
+              fontSize: '11px', color: '#888', textTransform: 'uppercase',
+              letterSpacing: '0.5px', marginBottom: '8px',
+            }}>
+              Validation ({validationIssues.length} issues)
+            </div>
+            {validationIssues.map((issue, i) => (
+              <div
+                key={i}
+                onClick={() => issue.cellPos && setSelectedCell(issue.cellPos)}
+                style={{
+                  padding: '4px 8px',
+                  fontSize: '12px',
+                  color: issue.severity === 'error' ? '#ff8888' :
+                         issue.severity === 'warning' ? '#ffcc66' : '#8888ff',
+                  cursor: issue.cellPos ? 'pointer' : 'default',
+                  borderRadius: '4px',
+                }}
+              >
+                {issue.severity === 'error' ? '[E]' : issue.severity === 'warning' ? '[W]' : '[I]'} {issue.message}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Right panel — Inspector */}
+      <div style={{
+        width: '280px',
+        borderLeft: '1px solid #333',
+        background: '#151525',
+        overflowY: 'auto',
+      }}>
+        {selectedCell ? (
+          <CellInspector
+            project={project}
+            selectedCell={selectedCell}
+            onUpdateCell={handleUpdateCell}
+            onSetStart={handleSetStart}
+            onSetEnd={handleSetEnd}
+            onToggleKey={handleToggleKey}
+            onToggleKeyGate={handleToggleKeyGate}
+            onClearCell={handleClearCell}
+            onChangeStage={handleChangeStage}
+          />
+        ) : (
+          <div style={{ padding: '1rem', color: '#888', fontSize: '13px' }}>
+            Click a cell to inspect or edit it.
+            <br /><br />
+            Click an empty cell to place a stage.
+          </div>
+        )}
+      </div>
+
+      {/* Stage picker modal */}
+      {pickerTarget && (
+        <StagePicker
+          project={project}
+          targetPos={pickerTarget}
+          onSelect={handlePlaceStage}
+          onClose={() => setPickerTarget(null)}
+        />
+      )}
+
+      {/* Generate dialog */}
+      {showGenDialog && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 1000,
+            background: 'rgba(0,0,0,0.7)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+          }}
+          onClick={() => setShowGenDialog(false)}
+        >
+          <div
+            style={{
+              background: '#1a1a2e',
+              border: '1px solid #444',
+              borderRadius: '12px',
+              padding: '24px',
+              width: '360px',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div style={{ fontSize: '16px', fontWeight: 700, color: '#fff', marginBottom: '16px' }}>
+              Generate Layout
+            </div>
+            <div style={{ fontSize: '12px', color: '#888', marginBottom: '16px' }}>
+              This will replace all current cells. You can undo with Ctrl+Z.
+            </div>
+
+            <label style={{ display: 'block', marginBottom: '12px' }}>
+              <div style={{ fontSize: '11px', color: '#888', marginBottom: '4px' }}>Path Length</div>
+              <input
+                type="number" min={3} max={project.gridSize * project.gridSize}
+                value={genParams.usedCells}
+                onChange={(e) => setGenParams(p => ({ ...p, usedCells: parseInt(e.target.value) || 8 }))}
+                style={{
+                  width: '100%', padding: '8px', background: '#2a2a4a',
+                  border: '1px solid #444', borderRadius: '4px', color: '#fff', fontSize: '13px',
+                }}
+              />
+            </label>
+
+            <label style={{ display: 'block', marginBottom: '12px' }}>
+              <div style={{ fontSize: '11px', color: '#888', marginBottom: '4px' }}>Key-Gates</div>
+              <input
+                type="number" min={0} max={5}
+                value={genParams.keyGates}
+                onChange={(e) => setGenParams(p => ({ ...p, keyGates: parseInt(e.target.value) || 0 }))}
+                style={{
+                  width: '100%', padding: '8px', background: '#2a2a4a',
+                  border: '1px solid #444', borderRadius: '4px', color: '#fff', fontSize: '13px',
+                }}
+              />
+            </label>
+
+            <label style={{ display: 'block', marginBottom: '16px' }}>
+              <div style={{ fontSize: '11px', color: '#888', marginBottom: '4px' }}>Dead-End Branches</div>
+              <input
+                type="number" min={0} max={5}
+                value={genParams.branches}
+                onChange={(e) => setGenParams(p => ({ ...p, branches: parseInt(e.target.value) || 0 }))}
+                style={{
+                  width: '100%', padding: '8px', background: '#2a2a4a',
+                  border: '1px solid #444', borderRadius: '4px', color: '#fff', fontSize: '13px',
+                }}
+              />
+            </label>
+
+            <div style={{ display: 'flex', gap: '8px' }}>
+              <button
+                onClick={handleGenerate}
+                style={{
+                  flex: 1, padding: '10px', background: '#5588ff', border: 'none',
+                  borderRadius: '6px', color: '#fff', fontSize: '14px',
+                  fontWeight: 600, cursor: 'pointer',
+                }}
+              >
+                Generate
+              </button>
+              <button
+                onClick={() => setShowGenDialog(false)}
+                style={{
+                  flex: 1, padding: '10px', background: '#444', border: 'none',
+                  borderRadius: '6px', color: '#fff', fontSize: '14px', cursor: 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/quest-editor/tabs/MetadataTab.tsx
+++ b/src/components/quest-editor/tabs/MetadataTab.tsx
@@ -1,0 +1,29 @@
+/**
+ * MetadataTab — Stub for Milestone 3
+ *
+ * Will allow editing quest metadata, message packs, and story triggers.
+ */
+
+export default function MetadataTab() {
+  return (
+    <div style={{
+      flex: 1,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      flexDirection: 'column',
+      gap: '16px',
+      color: '#888',
+    }}>
+      <div style={{ fontSize: '48px', opacity: 0.3 }}>3</div>
+      <div style={{ fontSize: '18px', fontWeight: 600, color: '#666' }}>
+        Metadata & Messages
+      </div>
+      <div style={{ fontSize: '13px', maxWidth: '400px', textAlign: 'center', lineHeight: 1.6 }}>
+        Milestone 3 will add quest metadata editing: quest name, description,
+        type, difficulty, recommended level, NPC message packs,
+        story triggers, and cutscene placement.
+      </div>
+    </div>
+  );
+}

--- a/src/components/quest-editor/tabs/MetadataTab.tsx
+++ b/src/components/quest-editor/tabs/MetadataTab.tsx
@@ -1,29 +1,193 @@
 /**
- * MetadataTab — Stub for Milestone 3
- *
- * Will allow editing quest metadata, message packs, and story triggers.
+ * MetadataTab — Edit quest metadata: name, description, type, difficulty, level
  */
 
-export default function MetadataTab() {
+import { useCallback } from 'react';
+import type { QuestProject, QuestMetadata } from '../types';
+
+interface MetadataTabProps {
+  project: QuestProject;
+  onUpdateProject: (updater: (prev: QuestProject) => QuestProject) => void;
+}
+
+const QUEST_TYPES: { value: QuestMetadata['questType']; label: string; desc: string }[] = [
+  { value: 'exploration', label: 'Exploration', desc: 'Reach the end of the field' },
+  { value: 'hunt', label: 'Hunt', desc: 'Defeat a target enemy or boss' },
+  { value: 'collection', label: 'Collection', desc: 'Gather items from the field' },
+  { value: 'escort', label: 'Escort', desc: 'Protect an NPC through the field' },
+  { value: 'story', label: 'Story', desc: 'Narrative-driven with cutscenes' },
+];
+
+const DIFFICULTIES: { value: string; label: string; color: string }[] = [
+  { value: 'normal', label: 'Normal', color: '#88ff88' },
+  { value: 'hard', label: 'Hard', color: '#ffcc44' },
+  { value: 'super', label: 'Super Hard', color: '#ff6666' },
+];
+
+export default function MetadataTab({ project, onUpdateProject }: MetadataTabProps) {
+  const meta = project.metadata;
+
+  const updateMeta = useCallback(<K extends keyof QuestMetadata>(key: K, value: QuestMetadata[K]) => {
+    onUpdateProject(prev => ({
+      ...prev,
+      metadata: { ...prev.metadata, [key]: value },
+    }));
+  }, [onUpdateProject]);
+
+  const updateName = useCallback((name: string) => {
+    onUpdateProject(prev => ({ ...prev, name }));
+  }, [onUpdateProject]);
+
   return (
     <div style={{
-      flex: 1,
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      flexDirection: 'column',
-      gap: '16px',
-      color: '#888',
+      flex: 1, display: 'flex', justifyContent: 'center',
+      overflow: 'auto', padding: '32px 24px',
     }}>
-      <div style={{ fontSize: '48px', opacity: 0.3 }}>3</div>
-      <div style={{ fontSize: '18px', fontWeight: 600, color: '#666' }}>
-        Metadata & Messages
-      </div>
-      <div style={{ fontSize: '13px', maxWidth: '400px', textAlign: 'center', lineHeight: 1.6 }}>
-        Milestone 3 will add quest metadata editing: quest name, description,
-        type, difficulty, recommended level, NPC message packs,
-        story triggers, and cutscene placement.
+      <div style={{ maxWidth: '560px', width: '100%', display: 'flex', flexDirection: 'column', gap: '24px' }}>
+
+        {/* Quest Name */}
+        <div>
+          <label style={labelStyle}>Quest Name</label>
+          <input
+            type="text"
+            value={project.name}
+            onChange={(e) => updateName(e.target.value)}
+            placeholder="e.g. Valley Expedition"
+            style={inputStyle}
+          />
+        </div>
+
+        {/* Description */}
+        <div>
+          <label style={labelStyle}>Mission Description</label>
+          <textarea
+            value={meta.description}
+            onChange={(e) => updateMeta('description', e.target.value)}
+            placeholder="Describe the mission objective and story context..."
+            rows={4}
+            style={{ ...inputStyle, resize: 'vertical', lineHeight: 1.6 }}
+          />
+          <div style={{ fontSize: '11px', color: '#666', marginTop: '4px' }}>
+            Shown to the player on the quest board and mission briefing screen.
+          </div>
+        </div>
+
+        {/* Quest Type */}
+        <div>
+          <label style={labelStyle}>Quest Type</label>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '6px' }}>
+            {QUEST_TYPES.map(qt => {
+              const selected = meta.questType === qt.value;
+              return (
+                <div
+                  key={qt.value}
+                  onClick={() => updateMeta('questType', qt.value)}
+                  style={{
+                    padding: '10px 14px',
+                    background: selected ? '#3a3a6a' : '#1a1a2e',
+                    border: `1px solid ${selected ? '#88aaff' : '#333'}`,
+                    borderRadius: '6px',
+                    cursor: 'pointer',
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <div>
+                    <span style={{ fontSize: '13px', fontWeight: 600, color: selected ? '#88aaff' : '#ccc' }}>
+                      {qt.label}
+                    </span>
+                    <span style={{ fontSize: '11px', color: '#888', marginLeft: '8px' }}>
+                      {qt.desc}
+                    </span>
+                  </div>
+                  {selected && (
+                    <div style={{ width: 8, height: 8, borderRadius: '50%', background: '#88aaff' }} />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Difficulty */}
+        <div>
+          <label style={labelStyle}>Difficulty</label>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            {DIFFICULTIES.map(d => {
+              const selected = meta.difficulty === d.value;
+              return (
+                <button
+                  key={d.value}
+                  onClick={() => updateMeta('difficulty', d.value as QuestMetadata['difficulty'])}
+                  style={{
+                    flex: 1,
+                    padding: '10px',
+                    background: selected ? d.color + '22' : '#1a1a2e',
+                    border: `1px solid ${selected ? d.color : '#333'}`,
+                    borderRadius: '6px',
+                    color: selected ? d.color : '#888',
+                    fontSize: '13px',
+                    fontWeight: selected ? 700 : 400,
+                    cursor: 'pointer',
+                  }}
+                >
+                  {d.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Recommended Level */}
+        <div>
+          <label style={labelStyle}>Recommended Level</label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <input
+              type="range"
+              min={1}
+              max={200}
+              value={meta.recommendedLevel}
+              onChange={(e) => updateMeta('recommendedLevel', parseInt(e.target.value))}
+              style={{ flex: 1 }}
+            />
+            <input
+              type="number"
+              min={1}
+              max={200}
+              value={meta.recommendedLevel}
+              onChange={(e) => updateMeta('recommendedLevel', Math.max(1, Math.min(200, parseInt(e.target.value) || 1)))}
+              style={{
+                ...inputStyle,
+                width: '70px',
+                textAlign: 'center',
+              }}
+            />
+          </div>
+        </div>
+
       </div>
     </div>
   );
 }
+
+const labelStyle: React.CSSProperties = {
+  display: 'block',
+  fontSize: '11px',
+  color: '#888',
+  textTransform: 'uppercase',
+  letterSpacing: '0.5px',
+  marginBottom: '6px',
+};
+
+const inputStyle: React.CSSProperties = {
+  width: '100%',
+  padding: '10px 12px',
+  background: '#1a1a2e',
+  border: '1px solid #333',
+  borderRadius: '6px',
+  color: '#fff',
+  fontSize: '14px',
+  fontFamily: 'inherit',
+  boxSizing: 'border-box',
+};

--- a/src/components/quest-editor/types.ts
+++ b/src/components/quest-editor/types.ts
@@ -52,6 +52,8 @@ export interface EditorGridCell {
   manual: boolean;
   /** Optional designer notes */
   notes?: string;
+  /** Authored 3D position for key pickup [x, y, z] in stage-local coords */
+  keyPosition?: [number, number, number];
 }
 
 // ============================================================================

--- a/src/components/quest-editor/types.ts
+++ b/src/components/quest-editor/types.ts
@@ -36,6 +36,43 @@ export const ROLE_LABELS: Record<CellRole, string> = {
 };
 
 // ============================================================================
+// Cell Objects (placed in 3D stage)
+// ============================================================================
+
+export type CellObjectType = 'box' | 'rare_box' | 'enemy' | 'fence' | 'step_switch';
+
+export interface CellObject {
+  /** Unique ID within cell (e.g., "box_0", "enemy_1") */
+  id: string;
+  /** Object type */
+  type: CellObjectType;
+  /** Stage-local position [x, y, z] */
+  position: [number, number, number];
+  /** Y-axis rotation in degrees */
+  rotation?: number;
+  /** Enemy ID for type='enemy' */
+  enemy_id?: string;
+  /** Links switch↔fence pairs with matching link_id */
+  link_id?: string;
+}
+
+export const CELL_OBJECT_COLORS: Record<CellObjectType, string> = {
+  box: '#aa6633',
+  rare_box: '#ddaa33',
+  enemy: '#cc4444',
+  fence: '#4488cc',
+  step_switch: '#44cc66',
+};
+
+export const CELL_OBJECT_LABELS: Record<CellObjectType, string> = {
+  box: 'Box',
+  rare_box: 'Rare Box',
+  enemy: 'Enemy',
+  fence: 'Fence',
+  step_switch: 'Switch',
+};
+
+// ============================================================================
 // Editor Grid Cell
 // ============================================================================
 
@@ -54,6 +91,8 @@ export interface EditorGridCell {
   notes?: string;
   /** Authored 3D position for key pickup [x, y, z] in stage-local coords */
   keyPosition?: [number, number, number];
+  /** Placed objects (boxes, enemies, fences, switches) */
+  objects?: CellObject[];
 }
 
 // ============================================================================

--- a/src/components/quest-editor/types.ts
+++ b/src/components/quest-editor/types.ts
@@ -44,6 +44,8 @@ export interface EditorGridCell {
   stageName: string;
   /** Rotation in degrees (0, 90, 180, 270). Only used for single-gate stages. */
   rotation?: number;
+  /** Which gate direction is key-locked on this cell */
+  lockedGate?: Direction;
   /** Cell role for visual and future content generation */
   role: CellRole;
   /** Whether this cell was manually placed (vs generated) */

--- a/src/components/quest-editor/types.ts
+++ b/src/components/quest-editor/types.ts
@@ -1,0 +1,155 @@
+/**
+ * Quest Editor Types
+ * Extends stage/types.ts with editor-specific data structures
+ */
+
+import type { StageContent, StageArea, ContentDifficulty, StageConfig } from '../../systems/stage/types';
+
+// ============================================================================
+// Directions (re-used from grid generation)
+// ============================================================================
+
+export type Direction = 'north' | 'south' | 'east' | 'west';
+
+// ============================================================================
+// Cell Roles
+// ============================================================================
+
+export type CellRole = 'transit' | 'guard' | 'puzzle' | 'cache' | 'landmark' | 'boss';
+
+export const ROLE_COLORS: Record<CellRole, string> = {
+  transit: '#666',
+  guard: '#cc4444',
+  puzzle: '#ccaa44',
+  cache: '#44aa44',
+  landmark: '#4488cc',
+  boss: '#cc8844',
+};
+
+export const ROLE_LABELS: Record<CellRole, string> = {
+  transit: 'Transit',
+  guard: 'Guard',
+  puzzle: 'Puzzle',
+  cache: 'Cache',
+  landmark: 'Landmark',
+  boss: 'Boss',
+};
+
+// ============================================================================
+// Editor Grid Cell
+// ============================================================================
+
+export interface EditorGridCell {
+  /** Stage ID with prefix (e.g., "s01a_ib1") */
+  stageName: string;
+  /** Rotation in degrees (0, 90, 180, 270). Only used for single-gate stages. */
+  rotation?: number;
+  /** Cell role for visual and future content generation */
+  role: CellRole;
+  /** Whether this cell was manually placed (vs generated) */
+  manual: boolean;
+  /** Optional designer notes */
+  notes?: string;
+}
+
+// ============================================================================
+// Quest Project (top-level save state)
+// ============================================================================
+
+export interface QuestProject {
+  /** Unique project ID */
+  id: string;
+  /** Project display name */
+  name: string;
+  /** Area key from STAGE_AREAS (e.g., "valley", "wetlands") */
+  areaKey: string;
+  /** Area variant ("a" or "b") */
+  variant: string;
+  /** Grid dimension (NxN) */
+  gridSize: number;
+  /** Sparse cell map, keyed by "row,col" */
+  cells: Record<string, EditorGridCell>;
+  /** Start cell position "row,col" or null */
+  startPos: string | null;
+  /** End cell position "row,col" or null */
+  endPos: string | null;
+  /** Key-gate links: gateCell "row,col" → keyCell "row,col" */
+  keyLinks: Record<string, string>;
+  /** Quest metadata */
+  metadata: QuestMetadata;
+  /** Per-cell content (Milestone 2 placeholder) */
+  cellContents: Record<string, StageContent>;
+  /** Last modified ISO timestamp */
+  lastModified: string;
+  /** Schema version */
+  version: number;
+}
+
+export interface QuestMetadata {
+  questName: string;
+  description: string;
+  questType: 'exploration' | 'hunt' | 'collection' | 'escort' | 'story';
+  difficulty: ContentDifficulty;
+  recommendedLevel: number;
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+export interface ValidationIssue {
+  severity: 'error' | 'warning' | 'info';
+  message: string;
+  cellPos?: string;
+}
+
+// ============================================================================
+// Area config for the editor (which areas have configs available)
+// ============================================================================
+
+export interface EditorAreaConfig {
+  key: string;
+  name: string;
+  prefix: string;
+  variants: string[];
+  available: boolean;
+}
+
+export const EDITOR_AREAS: EditorAreaConfig[] = [
+  { key: 'valley', name: 'Gurhacia Valley', prefix: 's01', variants: ['a', 'b'], available: true },
+  { key: 'wetlands', name: 'Ozette Wetlands', prefix: 's02', variants: ['a', 'b'], available: true },
+  { key: 'snowfield', name: 'Rioh Snowfield', prefix: 's03', variants: ['a', 'b'], available: true },
+  { key: 'makara', name: 'Makara Ruins', prefix: 's04', variants: ['a', 'b'], available: true },
+  { key: 'paru', name: 'Oblivion City Paru', prefix: 's05', variants: ['a', 'b'], available: true },
+  { key: 'arca', name: 'Arca Plant', prefix: 's06', variants: ['a', 'b'], available: false },
+  { key: 'shrine', name: 'Dark Shrine', prefix: 's07', variants: ['a', 'b'], available: false },
+  { key: 'tower', name: 'Eternal Tower', prefix: 's08', variants: [], available: false },
+];
+
+// ============================================================================
+// Factory
+// ============================================================================
+
+export function createDefaultProject(id?: string): QuestProject {
+  return {
+    id: id || crypto.randomUUID(),
+    name: 'New Quest',
+    areaKey: 'valley',
+    variant: 'a',
+    gridSize: 5,
+    cells: {},
+    startPos: null,
+    endPos: null,
+    keyLinks: {},
+    metadata: {
+      questName: '',
+      description: '',
+      questType: 'exploration',
+      difficulty: 'normal',
+      recommendedLevel: 1,
+    },
+    cellContents: {},
+    lastModified: new Date().toISOString(),
+    version: 1,
+  };
+}

--- a/src/components/storybook/StorybookViewer.tsx
+++ b/src/components/storybook/StorybookViewer.tsx
@@ -1,6 +1,8 @@
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, Grid } from '@react-three/drei';
-import { Suspense, useState, useMemo } from 'react';
+import { Suspense, useState, useMemo, useRef, useEffect, useCallback } from 'react';
+import { useFrame } from '@react-three/fiber';
+import * as THREE from 'three';
 import {
   Gate, gateMeta,
   KeyGate, keyGateMeta,
@@ -106,15 +108,183 @@ const CATEGORIES: CategoryEntry[] = [
 // Flatten for lookup
 const ALL_ELEMENTS = CATEGORIES.flatMap((cat) => cat.elements);
 
+// --- Texture inspector types ---
+
+interface TextureInfo {
+  name: string;
+  key: string;
+  filename: string;
+  texture: THREE.Texture;
+  meshName: string;
+}
+
+interface AnimatedTextureEntry {
+  key: string;
+  texture: THREE.Texture;
+  scrollX: number;
+  scrollY: number;
+}
+
+type WrapMode = 'repeat' | 'mirror' | 'clamp';
+
+function getTextureFilename(texture: THREE.Texture): string {
+  if (texture.name) {
+    const parts = texture.name.split('/');
+    return parts[parts.length - 1];
+  }
+  const image = texture.image as { src?: string } | null;
+  if (image && image.src) {
+    const parts = image.src.split('/');
+    return parts[parts.length - 1];
+  }
+  return 'unknown';
+}
+
+function getWrapModeName(mode: number): WrapMode {
+  if (mode === THREE.MirroredRepeatWrapping) return 'mirror';
+  if (mode === THREE.ClampToEdgeWrapping) return 'clamp';
+  return 'repeat';
+}
+
+function getThreeWrapMode(mode: WrapMode): THREE.Wrapping {
+  if (mode === 'mirror') return THREE.MirroredRepeatWrapping;
+  if (mode === 'clamp') return THREE.ClampToEdgeWrapping;
+  return THREE.RepeatWrapping;
+}
+
+// --- Canvas-internal components ---
+
+/** Scans a group for textures and reports them to the parent */
+function TextureScanner({
+  groupRef,
+  elementId,
+  state,
+  onTexturesFound,
+}: {
+  groupRef: React.RefObject<THREE.Group | null>;
+  elementId: string;
+  state: string;
+  onTexturesFound: (textures: TextureInfo[]) => void;
+}) {
+  const scanCount = useRef(0);
+
+  useFrame(() => {
+    // Scan on first few frames after element/state change to catch async GLB loads
+    if (scanCount.current < 10) {
+      scanCount.current++;
+      if (scanCount.current === 5 && groupRef.current) {
+        const instanceCounts: Record<string, number> = {};
+        const textureList: TextureInfo[] = [];
+
+        groupRef.current.traverse((object) => {
+          if (!(object as THREE.Mesh).isMesh) return;
+          const mesh = object as THREE.Mesh;
+          const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+
+          materials.forEach((mat) => {
+            const m = mat as any;
+            if (m.map && m.map instanceof THREE.Texture) {
+              const filename = getTextureFilename(m.map);
+              instanceCounts[filename] = (instanceCounts[filename] || 0) + 1;
+              const num = instanceCounts[filename];
+              const key = `${filename}#${num}`;
+
+              textureList.push({
+                name: `${filename} #${num}`,
+                key,
+                filename,
+                texture: m.map,
+                meshName: mesh.name,
+              });
+            }
+          });
+        });
+
+        onTexturesFound(textureList);
+      }
+    }
+  });
+
+  // Reset scan counter when element or state changes
+  useEffect(() => {
+    scanCount.current = 0;
+  }, [elementId, state]);
+
+  return null;
+}
+
+/** Animates texture offsets each frame */
+function TextureAnimator({ animatedTextures }: { animatedTextures: AnimatedTextureEntry[] }) {
+  useFrame((_, delta) => {
+    animatedTextures.forEach(({ texture, scrollX, scrollY }) => {
+      texture.offset.x += scrollX * delta;
+      texture.offset.y += scrollY * delta;
+      if (texture.offset.x > 10) texture.offset.x -= 10;
+      if (texture.offset.x < -10) texture.offset.x += 10;
+      if (texture.offset.y > 10) texture.offset.y -= 10;
+      if (texture.offset.y < -10) texture.offset.y += 10;
+    });
+  });
+  return null;
+}
+
+/** Element IDs that should spin and bob */
+const SPINNING_ELEMENTS = new Set([
+  'key', 'drop-meseta', 'drop-weapon', 'drop-armor', 'drop-rare', 'drop-item',
+]);
+
+/** Spins the group for pickup/drop elements */
+function ModelSpinner({
+  groupRef,
+  elementId,
+  state,
+}: {
+  groupRef: React.RefObject<THREE.Group | null>;
+  elementId: string;
+  state: string;
+}) {
+  const timeRef = useRef(0);
+
+  useFrame((_, delta) => {
+    if (!groupRef.current) return;
+    if (!SPINNING_ELEMENTS.has(elementId)) return;
+    if (state !== 'available') return;
+
+    timeRef.current += delta;
+    groupRef.current.rotation.y += delta * 2;
+    groupRef.current.position.y = Math.sin(timeRef.current * 3) * 0.1;
+  });
+
+  // Reset rotation/position when element changes
+  useEffect(() => {
+    if (groupRef.current) {
+      groupRef.current.rotation.y = 0;
+      groupRef.current.position.y = 0;
+    }
+    timeRef.current = 0;
+  }, [elementId, groupRef]);
+
+  return null;
+}
+
 function ElementPreview({ element, state }: { element: ElementEntry; state: string }) {
   const { Component } = element;
 
   return (
     <Suspense fallback={null}>
-      <Component state={state} />
+      <Component key={element.id} state={state} />
     </Suspense>
   );
 }
+
+// --- Shared styles ---
+const WRAP_MODES: { value: WrapMode; label: string }[] = [
+  { value: 'repeat', label: 'Repeat' },
+  { value: 'mirror', label: 'Mirror' },
+  { value: 'clamp', label: 'Clamp' },
+];
+
+// --- Main component ---
 
 export default function StorybookViewer() {
   const [selectedId, setSelectedId] = useState<string>(ALL_ELEMENTS[0].id);
@@ -135,6 +305,169 @@ export default function StorybookViewer() {
   const handleStateChange = (newState: string) => {
     setStates((prev) => ({ ...prev, [selectedId]: newState }));
   };
+
+  // Texture inspector state
+  const groupRef = useRef<THREE.Group>(null);
+  const [textures, setTextures] = useState<TextureInfo[]>([]);
+  const [selectedTexIdx, setSelectedTexIdx] = useState(0);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+
+  // Per-texture editing state
+  const [repeatX, setRepeatX] = useState(1);
+  const [repeatY, setRepeatY] = useState(1);
+  const [offsetX, setOffsetX] = useState(0);
+  const [offsetY, setOffsetY] = useState(0);
+  const [scrollX, setScrollX] = useState(0);
+  const [scrollY, setScrollY] = useState(0);
+  const [wrapS, setWrapS] = useState<WrapMode>('repeat');
+  const [wrapT, setWrapT] = useState<WrapMode>('repeat');
+
+  const selectedTexture = textures[selectedTexIdx] || null;
+
+  // Animated textures for TextureAnimator
+  const [animatedTextures, setAnimatedTextures] = useState<AnimatedTextureEntry[]>([]);
+
+  // When textures are found by scanner
+  const handleTexturesFound = useCallback((newTextures: TextureInfo[]) => {
+    setTextures(newTextures);
+    setSelectedTexIdx(0);
+    setAnimatedTextures([]);
+  }, []);
+
+  // When selected texture changes, load its current values
+  useEffect(() => {
+    if (!selectedTexture) {
+      setPreviewUrl(null);
+      return;
+    }
+
+    const tex = selectedTexture.texture;
+    setRepeatX(tex.repeat.x);
+    setRepeatY(tex.repeat.y);
+    setOffsetX(tex.offset.x);
+    setOffsetY(tex.offset.y);
+    setWrapS(getWrapModeName(tex.wrapS));
+    setWrapT(getWrapModeName(tex.wrapT));
+    setScrollX(0);
+    setScrollY(0);
+
+    // Generate preview
+    const image = tex.image as CanvasImageSource | null;
+    if (image) {
+      try {
+        const canvas = document.createElement('canvas');
+        canvas.width = 128;
+        canvas.height = 128;
+        const ctx = canvas.getContext('2d');
+        if (ctx) {
+          ctx.drawImage(image, 0, 0, 128, 128);
+          setPreviewUrl(canvas.toDataURL());
+        }
+      } catch {
+        setPreviewUrl(null);
+      }
+    } else {
+      setPreviewUrl(null);
+    }
+  }, [selectedTexture]);
+
+  // Apply changes to texture in real-time
+  useEffect(() => {
+    if (!selectedTexture) return;
+    const tex = selectedTexture.texture;
+    tex.repeat.set(repeatX, repeatY);
+    tex.offset.set(offsetX, offsetY);
+    tex.wrapS = getThreeWrapMode(wrapS);
+    tex.wrapT = getThreeWrapMode(wrapT);
+    tex.needsUpdate = true;
+  }, [repeatX, repeatY, offsetX, offsetY, wrapS, wrapT, selectedTexture]);
+
+  // Update animated textures when scroll values change
+  useEffect(() => {
+    if (!selectedTexture) return;
+    setAnimatedTextures((prev) => {
+      // Remove this texture's old entry
+      const filtered = prev.filter((a) => a.key !== selectedTexture.key);
+      // Add if scrolling
+      if (scrollX !== 0 || scrollY !== 0) {
+        filtered.push({
+          key: selectedTexture.key,
+          texture: selectedTexture.texture,
+          scrollX,
+          scrollY,
+        });
+      }
+      return filtered;
+    });
+  }, [scrollX, scrollY, selectedTexture]);
+
+  // Reset animated textures when element changes
+  useEffect(() => {
+    setAnimatedTextures([]);
+    setTextures([]);
+    setSelectedTexIdx(0);
+  }, [selectedId]);
+
+  const handleReset = () => {
+    setRepeatX(1);
+    setRepeatY(1);
+    setOffsetX(0);
+    setOffsetY(0);
+    setScrollX(0);
+    setScrollY(0);
+    setWrapS('repeat');
+    setWrapT('repeat');
+  };
+
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyConfig = useCallback(() => {
+    if (textures.length === 0) return;
+
+    const lines: string[] = [];
+    lines.push(`// Texture config for ${selectedElement.meta.title}`);
+    lines.push('const TEXTURE_CONFIG: Record<string, {');
+    lines.push('  offsetX?: number; offsetY?: number;');
+    lines.push('  repeatX?: number; repeatY?: number;');
+    lines.push('  wrapS?: string; wrapT?: string;');
+    lines.push('  scrollX?: number; scrollY?: number;');
+    lines.push('}> = {');
+
+    // Deduplicate by filename (multiple instances of same texture share settings)
+    const seen = new Set<string>();
+    textures.forEach((t) => {
+      if (seen.has(t.filename)) return;
+      seen.add(t.filename);
+
+      const tex = t.texture;
+      const anim = animatedTextures.find((a) => a.key === t.key);
+
+      const props: string[] = [];
+      // Always include offset and repeat for clarity
+      props.push(`offsetX: ${tex.offset.x.toFixed(2)}, offsetY: ${tex.offset.y.toFixed(2)}`);
+      props.push(`repeatX: ${tex.repeat.x.toFixed(1)}, repeatY: ${tex.repeat.y.toFixed(1)}`);
+
+      const ws = getWrapModeName(tex.wrapS);
+      const wt = getWrapModeName(tex.wrapT);
+      if (ws !== 'repeat' || wt !== 'repeat') {
+        props.push(`wrapS: '${ws}', wrapT: '${wt}'`);
+      }
+
+      if (anim && (anim.scrollX !== 0 || anim.scrollY !== 0)) {
+        props.push(`scrollX: ${anim.scrollX.toFixed(2)}, scrollY: ${anim.scrollY.toFixed(2)}`);
+      }
+
+      lines.push(`  '${t.filename}': { ${props.join(', ')} }, // mesh: ${t.meshName}`);
+    });
+
+    lines.push('};');
+
+    const snippet = lines.join('\n');
+    navigator.clipboard.writeText(snippet).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [textures, animatedTextures, selectedElement]);
 
   return (
     <div style={{
@@ -218,7 +551,7 @@ export default function StorybookViewer() {
               e.currentTarget.style.background = 'transparent';
             }}
           >
-            ← Back to Home
+            &larr; Back to Home
           </a>
         </div>
       </div>
@@ -229,7 +562,22 @@ export default function StorybookViewer() {
           <ambientLight intensity={0.6} />
           <directionalLight position={[5, 10, 5]} intensity={0.8} />
 
-          <ElementPreview element={selectedElement} state={currentState} />
+          <group ref={groupRef}>
+            <ElementPreview element={selectedElement} state={currentState} />
+          </group>
+
+          <TextureScanner
+            groupRef={groupRef}
+            elementId={selectedId}
+            state={currentState}
+            onTexturesFound={handleTexturesFound}
+          />
+          <TextureAnimator animatedTextures={animatedTextures} />
+          <ModelSpinner
+            groupRef={groupRef}
+            elementId={selectedId}
+            state={currentState}
+          />
 
           <OrbitControls />
           <Grid
@@ -260,14 +608,15 @@ export default function StorybookViewer() {
         </div>
       </div>
 
-      {/* Right Panel - State Controls */}
+      {/* Right Panel - State Controls + Texture Inspector */}
       <div style={{
-        width: '280px',
+        width: '300px',
         borderLeft: '1px solid #333',
         overflow: 'auto',
         padding: '1.5rem',
         background: '#151525',
       }}>
+        {/* State section */}
         <div style={{
           fontSize: '11px',
           color: '#666',
@@ -333,97 +682,238 @@ export default function StorybookViewer() {
           })}
         </div>
 
-        {/* Props Info */}
-        <div style={{ marginTop: '2rem' }}>
+        {/* Texture Inspector */}
+        <div style={{ marginTop: '2rem', borderTop: '1px solid #333', paddingTop: '1rem' }}>
           <div style={{
             fontSize: '11px',
             color: '#666',
             textTransform: 'uppercase',
             letterSpacing: '1px',
-            marginBottom: '0.75rem',
+            marginBottom: '1rem',
           }}>
-            Current Props
+            Textures {textures.length > 0 && `(${textures.length})`}
           </div>
-          <pre style={{
-            background: '#1a1a2e',
-            padding: '12px',
-            borderRadius: '6px',
-            fontSize: '12px',
-            color: '#88aaff',
-            overflow: 'auto',
-            margin: 0,
-          }}>
-{`<${selectedElement.meta.title.replace(/[:\s]/g, '')}
-  state="${currentState}"
-/>`}
-          </pre>
-        </div>
 
-        {/* Usage Notes */}
-        <div style={{ marginTop: '2rem' }}>
-          <div style={{
-            fontSize: '11px',
-            color: '#666',
-            textTransform: 'uppercase',
-            letterSpacing: '1px',
-            marginBottom: '0.75rem',
-          }}>
-            Usage
-          </div>
-          <div style={{
-            fontSize: '12px',
-            color: '#888',
-            lineHeight: '1.6',
-          }}>
-            {getUsageText(selectedElement.id)}
-          </div>
+          {textures.length === 0 ? (
+            <div style={{ fontSize: '12px', color: '#555' }}>
+              No textures found.
+            </div>
+          ) : (
+            <>
+              {/* Texture selector */}
+              <select
+                value={selectedTexIdx}
+                onChange={(e) => setSelectedTexIdx(Number(e.target.value))}
+                style={{
+                  width: '100%',
+                  padding: '8px',
+                  background: '#252540',
+                  color: 'white',
+                  border: '1px solid #444',
+                  borderRadius: '4px',
+                  fontFamily: 'monospace',
+                  fontSize: '11px',
+                  marginBottom: '12px',
+                }}
+              >
+                {textures.map((t, i) => (
+                  <option key={i} value={i}>
+                    {t.name} ({t.meshName})
+                  </option>
+                ))}
+              </select>
+
+              {/* Preview + info */}
+              <div style={{ display: 'flex', gap: '12px', marginBottom: '12px' }}>
+                {previewUrl && (
+                  <img
+                    src={previewUrl}
+                    alt="Texture preview"
+                    style={{
+                      width: '96px',
+                      height: '96px',
+                      border: '2px solid #444',
+                      borderRadius: '4px',
+                      imageRendering: 'pixelated',
+                      flexShrink: 0,
+                    }}
+                  />
+                )}
+                {selectedTexture && (
+                  <div style={{ fontSize: '11px', color: '#888', lineHeight: '1.6' }}>
+                    <div>Mesh: <span style={{ color: '#aaa' }}>{selectedTexture.meshName}</span></div>
+                    <div>File: <span style={{ color: '#4a9eff' }}>{selectedTexture.filename}</span></div>
+                    <div>Size: <span style={{ color: '#aaa' }}>
+                      {(selectedTexture.texture.image as any)?.width || '?'}x{(selectedTexture.texture.image as any)?.height || '?'}
+                    </span></div>
+                  </div>
+                )}
+              </div>
+
+              {/* Controls */}
+              <div style={{ background: '#1a1a2e', padding: '12px', borderRadius: '4px', marginBottom: '12px' }}>
+                {/* Offset X */}
+                <div style={{ marginBottom: '12px' }}>
+                  <label style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px', fontSize: '12px' }}>
+                    <span>Offset X</span>
+                    <span style={{ color: '#4a9eff' }}>{offsetX.toFixed(2)}</span>
+                  </label>
+                  <input type="range" min="-2" max="2" step="0.01" value={offsetX}
+                    onChange={(e) => setOffsetX(Number(e.target.value))} style={{ width: '100%' }} />
+                </div>
+
+                {/* Offset Y */}
+                <div style={{ marginBottom: '12px' }}>
+                  <label style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px', fontSize: '12px' }}>
+                    <span>Offset Y</span>
+                    <span style={{ color: '#4a9eff' }}>{offsetY.toFixed(2)}</span>
+                  </label>
+                  <input type="range" min="-2" max="2" step="0.01" value={offsetY}
+                    onChange={(e) => setOffsetY(Number(e.target.value))} style={{ width: '100%' }} />
+                </div>
+
+                {/* Repeat X */}
+                <div style={{ marginBottom: '12px' }}>
+                  <label style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px', fontSize: '12px' }}>
+                    <span>Repeat X</span>
+                    <span style={{ color: '#4a9eff' }}>{repeatX.toFixed(1)}</span>
+                  </label>
+                  <input type="range" min="0.1" max="10" step="0.1" value={repeatX}
+                    onChange={(e) => setRepeatX(Number(e.target.value))} style={{ width: '100%' }} />
+                </div>
+
+                {/* Repeat Y */}
+                <div style={{ marginBottom: '12px' }}>
+                  <label style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px', fontSize: '12px' }}>
+                    <span>Repeat Y</span>
+                    <span style={{ color: '#4a9eff' }}>{repeatY.toFixed(1)}</span>
+                  </label>
+                  <input type="range" min="0.1" max="10" step="0.1" value={repeatY}
+                    onChange={(e) => setRepeatY(Number(e.target.value))} style={{ width: '100%' }} />
+                </div>
+
+                {/* Wrap S */}
+                <div style={{ marginBottom: '12px' }}>
+                  <label style={{ display: 'block', marginBottom: '4px', fontSize: '12px' }}>Wrap S</label>
+                  <div style={{ display: 'flex', gap: '4px' }}>
+                    {WRAP_MODES.map((mode) => (
+                      <button
+                        key={mode.value}
+                        onClick={() => setWrapS(mode.value)}
+                        style={{
+                          flex: 1,
+                          padding: '5px',
+                          background: wrapS === mode.value ? '#4a9eff' : '#333',
+                          color: 'white',
+                          border: 'none',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                          fontSize: '11px',
+                        }}
+                      >
+                        {mode.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                {/* Wrap T */}
+                <div style={{ marginBottom: '4px' }}>
+                  <label style={{ display: 'block', marginBottom: '4px', fontSize: '12px' }}>Wrap T</label>
+                  <div style={{ display: 'flex', gap: '4px' }}>
+                    {WRAP_MODES.map((mode) => (
+                      <button
+                        key={mode.value}
+                        onClick={() => setWrapT(mode.value)}
+                        style={{
+                          flex: 1,
+                          padding: '5px',
+                          background: wrapT === mode.value ? '#4a9eff' : '#333',
+                          color: 'white',
+                          border: 'none',
+                          borderRadius: '4px',
+                          cursor: 'pointer',
+                          fontSize: '11px',
+                        }}
+                      >
+                        {mode.label}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* Scroll animation */}
+              <div style={{
+                background: '#2a1a3e',
+                padding: '12px',
+                borderRadius: '4px',
+                border: '1px solid #4a3a5e',
+                marginBottom: '12px',
+              }}>
+                <div style={{ fontSize: '12px', color: '#a8f', marginBottom: '10px', fontWeight: 'bold' }}>
+                  Scroll Animation
+                </div>
+
+                <div style={{ marginBottom: '10px' }}>
+                  <label style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px', fontSize: '12px' }}>
+                    <span>Scroll X</span>
+                    <span style={{ color: scrollX !== 0 ? '#a8f' : '#666' }}>{scrollX.toFixed(2)}</span>
+                  </label>
+                  <input type="range" min="-2" max="2" step="0.05" value={scrollX}
+                    onChange={(e) => setScrollX(Number(e.target.value))} style={{ width: '100%' }} />
+                </div>
+
+                <div>
+                  <label style={{ display: 'flex', justifyContent: 'space-between', marginBottom: '4px', fontSize: '12px' }}>
+                    <span>Scroll Y</span>
+                    <span style={{ color: scrollY !== 0 ? '#a8f' : '#666' }}>{scrollY.toFixed(2)}</span>
+                  </label>
+                  <input type="range" min="-2" max="2" step="0.05" value={scrollY}
+                    onChange={(e) => setScrollY(Number(e.target.value))} style={{ width: '100%' }} />
+                </div>
+              </div>
+
+              {/* Reset + Copy */}
+              <div style={{ display: 'flex', gap: '8px' }}>
+                <button
+                  onClick={handleReset}
+                  style={{
+                    flex: 1,
+                    padding: '8px',
+                    background: '#c86432',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontWeight: 'bold',
+                    fontSize: '12px',
+                  }}
+                >
+                  Reset
+                </button>
+                <button
+                  onClick={handleCopyConfig}
+                  style={{
+                    flex: 1,
+                    padding: '8px',
+                    background: copied ? '#4a4' : '#4a9eff',
+                    color: 'white',
+                    border: 'none',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontWeight: 'bold',
+                    fontSize: '12px',
+                    transition: 'background 0.2s',
+                  }}
+                >
+                  {copied ? 'Copied!' : 'Copy Config'}
+                </button>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </div>
   );
-}
-
-function getUsageText(elementId: string): string {
-  switch (elementId) {
-    case 'gate':
-      return 'Gates block passage between stages in the grid. They open automatically when all enemies in the stage are defeated.';
-    case 'key-gate':
-      return 'Key Gates block passage and require a Key pickup to unlock. Unlike regular gates, they do not open by defeating enemies.';
-    case 'fence':
-      return 'Fences block access to items or keys within a stage. They are disabled by activating an InteractSwitch.';
-    case 'fence-4':
-      return 'Four-sided fence that blocks access from all directions. Works the same as regular fences but provides 360-degree coverage.';
-    case 'key':
-      return 'Keys are pickup items that unlock KeyGates. They float and rotate when available, disappear when collected.';
-    case 'interact-switch':
-      return 'Players interact with these switches to disable fences. Typically placed near the fence they control.';
-    case 'step-switch':
-      return 'Pressure plates that activate when stepped on. Used for contextual triggers like traps, lights, or debug functions.';
-    case 'remote-switch':
-      return 'Interactive switch used to disarm traps or trigger remote mechanisms. Player must interact to activate.';
-    case 'drop-meseta':
-      return 'Currency drops from defeated enemies. Auto-collected when the player walks near.';
-    case 'drop-weapon':
-      return 'Weapon drops from defeated enemies or containers. Must be picked up manually.';
-    case 'drop-armor':
-      return 'Armor/protector drops from defeated enemies or containers. Must be picked up manually.';
-    case 'drop-rare':
-      return 'Rare item drops. These have a distinct appearance to indicate their rarity.';
-    case 'drop-item':
-      return 'Generic item drops like consumables or materials. Must be picked up manually.';
-    case 'waypoint':
-      return 'Navigation indicators placed in load triggers. Shows different icons based on whether the destination has been visited.';
-    case 'box':
-      return 'Destructible containers that may drop items when destroyed. Model varies by field.';
-    case 'rare-box':
-      return 'Special containers that drop valuable items when destroyed. Model varies by field.';
-    case 'wall':
-      return 'Destructible walls that block passage until destroyed. Model varies by field.';
-    case 'start-warp':
-      return 'Warp point at the start of an area. Players spawn here when entering the area. Model varies by field.';
-    case 'area-warp':
-      return 'Warp gate to the next area. Players pass through this to advance to the next section. Model varies by field.';
-    default:
-      return '';
-  }
 }

--- a/src/content/quests/hello-world.json
+++ b/src/content/quests/hello-world.json
@@ -1,0 +1,60 @@
+{
+  "id": "hello_world",
+  "name": "Hello World",
+  "area_id": "gurhacia",
+  "sections": [
+    {
+      "type": "grid",
+      "area": "a",
+      "start_pos": "0,1",
+      "end_pos": "2,1",
+      "cells": [
+        {
+          "pos": "0,1",
+          "stage_id": "s01a_sa1",
+          "rotation": 0,
+          "connections": { "south": "1,1" },
+          "is_start": true,
+          "is_end": false,
+          "is_branch": false,
+          "has_key": false,
+          "key_for_cell": "",
+          "is_key_gate": false,
+          "key_gate_direction": "",
+          "warp_edge": "",
+          "path_order": 0
+        },
+        {
+          "pos": "1,1",
+          "stage_id": "s01a_ib1",
+          "rotation": 0,
+          "connections": { "north": "0,1", "south": "2,1" },
+          "is_start": false,
+          "is_end": false,
+          "is_branch": false,
+          "has_key": false,
+          "key_for_cell": "",
+          "is_key_gate": false,
+          "key_gate_direction": "",
+          "warp_edge": "",
+          "path_order": 1
+        },
+        {
+          "pos": "2,1",
+          "stage_id": "s01a_ga1",
+          "rotation": 0,
+          "connections": { "north": "1,1" },
+          "is_start": false,
+          "is_end": true,
+          "is_branch": false,
+          "has_key": false,
+          "key_for_cell": "",
+          "is_key_gate": false,
+          "key_gate_direction": "",
+          "warp_edge": "south",
+          "path_order": 2
+        }
+      ]
+    }
+  ]
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,6 +23,7 @@ const sections = [
       { href: '/stage/stage-editor', label: 'Stage Editor', description: 'Edit floor collision, portals, and export GLB', color: '#ff8844' },
       { href: '/preview-mission', label: 'Mission Preview', description: 'Walk through stage loading', color: '#ff55aa' },
       { href: '/grid', label: 'Grid Viewer', description: 'Test gate alignment in 5x5 grid', color: '#55aaaa' },
+      { href: '/quest-editor', label: 'Quest Editor', description: 'Design authored quest layouts with grid editor', color: '#44ccaa' },
     ]
   },
   {

--- a/src/pages/quest-editor.astro
+++ b/src/pages/quest-editor.astro
@@ -1,0 +1,18 @@
+---
+import Layout from '../layouts/Layout.astro';
+import QuestEditor from '../components/quest-editor/QuestEditor';
+
+export const prerender = false;
+---
+
+<Layout title="Quest Editor - PSZ">
+  <QuestEditor client:load />
+</Layout>
+
+<style is:global>
+  body {
+    overflow: hidden !important;
+    margin: 0;
+    padding: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary
- **Object placement UI** in ContentTab: palette for box, rare box, enemy, fence, and step switch placement in 3D cell preview
- **Enemy picker**: Dropdown to select enemy_id when placing enemy spawns
- **Link system**: Fence and switch objects share `link_id` to define puzzle connections
- **Metadata tab**: Quest description field editing
- **Export/import**: `objects` array per cell with type, position, rotation, enemy_id, link_id

## Test plan
- [x] Place objects in 3D cell preview via palette buttons
- [x] Export quest JSON includes `objects` array per cell
- [x] Import quest JSON restores objects in editor
- [x] Description field round-trips through export/import

🤖 Generated with [Claude Code](https://claude.com/claude-code)